### PR TITLE
try overriding nixos-rebuild using custom nix-monitored overlay

### DIFF
--- a/nix/config.nix
+++ b/nix/config.nix
@@ -10,6 +10,8 @@ in
       nix = final.lixPackageSets.stable.lix;
     })
     (import sources.emacs-overlay)
+
+    (import (sources.leana-dotfiles + "/nix/overlays/nix-monitored.nix"))
   ];
 
   # make sure the nix daemon uses all memory

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1,5 +1,19 @@
 {
   "pins": {
+    "leana-dotfiles": {
+      "type": "Git",
+      "repository": {
+        "type": "Forgejo",
+        "server": "https://codeberg.org/",
+        "owner": "leana8959",
+        "repo": ".files"
+      },
+      "branch": "trunk",
+      "submodules": false,
+      "revision": "5f665b4f556a6bb1edef57b2a98ce8b745469fb4",
+      "url": "https://codeberg.org/leana8959/.files/archive/5f665b4f556a6bb1edef57b2a98ce8b745469fb4.tar.gz",
+      "hash": "0zs8x70f10rjil0dk8zzbcpaw06bqi8x0djxdqcnkmik3fjp24bg"
+    },
     "agenix": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
This should give you nom in nixos-rebuild with my ugly hack.

If it doesn't work, just remove the overlay.