### PR TITLE
Forward PATH to systemd so waybar on-click works

### DIFF
--- a/dotfiles/jappie/.config/sway/config
+++ b/dotfiles/jappie/.config/sway/config
@@ -7,7 +7,7 @@
 
 # sway stuff
 
-exec dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP SWAYSOCK
+exec dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP SWAYSOCK PATH
 exec systemctl --user start sway-session.target
 
 # i3 config file (v4)


### PR DESCRIPTION
## Summary

- Add `PATH` to the `dbus-update-activation-environment --systemd` call in sway config

## Problem

Since waybar runs as a systemd service (via `sway-session.target`), it doesn't inherit sway's shell environment. The `dbus-update-activation-environment` call only forwarded `WAYLAND_DISPLAY`, `XDG_CURRENT_DESKTOP`, and `SWAYSOCK` — but not `PATH`. This meant waybar's `on-click` handlers (`foot`, `firefox`, `pavucontrol`, `btop`, etc.) couldn't find their binaries.

## Test plan

- [ ] Reboot or restart sway
- [ ] Click a waybar module (e.g. CPU to open btop, clock for calendar)
- [ ] Verify the program launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)