### PR TITLE
Add nix-builder user and openssh for container remote builds

### DIFF
--- a/nix/config.nix
+++ b/nix/config.nix
@@ -45,6 +45,7 @@ in
 
       trusted-users = [
         "root"
+        "nix-builder"
       ];
       extra-substituters = [
         "https://cache.nixos.org"
@@ -64,6 +65,19 @@ in
       ];
       auto-optimise-store = false;
     };
+  };
+
+  # Restricted user for Claude container remote nix builds
+  # No sudo, no wheel, no shell — only nix-daemon --stdio via SSH
+  users.users.nix-builder = {
+    isNormalUser = true;
+    home = "/var/lib/nix-builder";
+    createHome = true;
+    group = "nogroup";
+    shell = pkgs.shadow + "/bin/nologin";
+    openssh.authorizedKeys.keys = [
+      ''command="nix-daemon --stdio",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF9jwwrWQthxzsIDXpE0oA6jMDjXIPwUPrN6Evm6DY2L jappeace-sloth-tablet''
+    ];
   };
 
   system.nixos =

--- a/nix/services.nix
+++ b/nix/services.nix
@@ -28,6 +28,15 @@
 
   services = {
 
+    # Allow Claude containers to SSH in for remote nix builds
+    openssh = {
+      enable = true;
+      settings = {
+        PasswordAuthentication = false;
+        PermitRootLogin = "no";
+      };
+    };
+
     syncthing = {
       overrideDevices = true;
       overrideFolders = true;

--- a/nix/services.nix
+++ b/nix/services.nix
@@ -29,8 +29,13 @@
   services = {
 
     # Allow Claude containers to SSH in for remote nix builds
+    # Only listens on localhost and docker bridge — not reachable from the network
     openssh = {
       enable = true;
+      listenAddresses = [
+        { addr = "127.0.0.1"; }
+        { addr = "172.17.0.1"; }
+      ];
       settings = {
         PasswordAuthentication = false;
         PermitRootLogin = "no";


### PR DESCRIPTION
## Summary
- Enables openssh with key-only auth, no root login
- Creates restricted `nix-builder` user: no sudo, no wheel, `nologin` shell
- SSH `command=` restriction limits connections to `nix-daemon --stdio` only
- No port/X11/agent forwarding allowed
- Adds `nix-builder` to nix `trusted-users`

## Security
The `nix-builder` user cannot:
- Get an interactive shell (nologin + forced command)
- Escalate privileges (not in wheel/sudo)
- Forward ports or tunnel traffic

## Companion PR
Used by jappeace/haskell-vibes ssh-remote-builder branch for container-side remote builder config.

## Test plan
- [ ] `nixos-rebuild switch` succeeds
- [ ] `ssh nix-builder@localhost` responds with nix-daemon protocol (not a shell)
- [ ] Container can delegate builds to host

🤖 Generated with [Claude Code](https://claude.com/claude-code)