### PR TITLE
Fix nix-builder shell: nologin breaks ssh-ng protocol

### DIFF
--- a/nix/config.nix
+++ b/nix/config.nix
@@ -69,13 +69,17 @@ in
   };
 
   # Restricted user for Claude container remote nix builds
-  # No sudo, no wheel, no shell — only nix-daemon --stdio via SSH
+  # No sudo, no wheel — only nix-daemon --stdio via SSH forced command
+  # Shell must be bash (not nologin) because sshd runs forced commands via
+  # the user's login shell: `$SHELL -c "nix-daemon --stdio"`.
+  # nologin ignores -c, prints "This account is currently not available."
+  # and exits — corrupting the nix ssh-ng protocol handshake.
   users.users.nix-builder = {
     isNormalUser = true;
     home = "/var/lib/nix-builder";
     createHome = true;
     group = "nogroup";
-    shell = pkgs.shadow + "/bin/nologin";
+    shell = pkgs.bash + "/bin/bash";
     openssh.authorizedKeys.keys = [
       ''command="nix-daemon --stdio",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF9jwwrWQthxzsIDXpE0oA6jMDjXIPwUPrN6Evm6DY2L jappeace-sloth-tablet''
     ];


### PR DESCRIPTION
## Summary
- Change nix-builder user shell from `nologin` to `bash` to fix remote nix builds via `ssh-ng://`
- `sshd` runs forced commands (`command=` in authorized_keys) via the user's login shell: `$SHELL -c "nix-daemon --stdio"`
- With `nologin` as shell, this prints "This account is currently not available." and exits — corrupting the nix protocol handshake and causing `protocol mismatch` errors
- Security is still enforced by the SSH `command=` restriction — the key can only ever run `nix-daemon --stdio`

## Test plan
- [ ] Rebuild NixOS (`nixos-rebuild switch`)
- [ ] Rebuild haskell-vibes container
- [ ] Run `test-plan-lix-and-etc-fix.sh` inside container — section 5 (remote builder) should now pass
- [ ] Verify `nix-build` inside container delegates to host successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)