### PR TITLE
Move post-build-hook to lenovo-tablet only

### DIFF
--- a/lenovo-tablet.nix
+++ b/lenovo-tablet.nix
@@ -1,6 +1,16 @@
   {  pkgs, ... }:
 let
   monitor-script = pkgs.writeShellScriptBin "monitor" ./scripts/laptop-monitor.sh;
+
+  # Push every successful build to the megavid binary cache.
+  # Only on this machine — the work machines are used for client projects.
+  pushToCacheScript = pkgs.writeShellScript "push-to-binary-cache" ''
+    set -uf
+    echo "pushing to binary cache: $OUT_PATHS" >&2
+    NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new" \
+      ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org $OUT_PATHS 2>&1 || \
+      echo "WARNING: failed to push to binary cache" >&2
+  '';
 in
 {
 
@@ -393,5 +403,7 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
     enable = true;
     cpuFreqGovernor = "ondemand";
   };
+
+  nix.settings.post-build-hook = "${pushToCacheScript}";
 
 }

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -2,17 +2,6 @@
 { pkgs, ... }:
 let
   sources = import ../npins;
-
-  # After every successful build, push the result to the megavid binary cache.
-  # Uses jappie's SSH key since the nix daemon runs as root but root
-  # doesn't have its own key authorized on the remote.
-  pushToCacheScript = pkgs.writeShellScript "push-to-binary-cache" ''
-    set -uf
-    echo "pushing to binary cache: $OUT_PATHS" >&2
-    NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new" \
-      ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org $OUT_PATHS 2>&1 || \
-      echo "WARNING: failed to push to binary cache" >&2
-  '';
 in
 {
   nixpkgs.overlays = [
@@ -76,7 +65,6 @@ in
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
         "nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc="
       ];
-      post-build-hook = "${pushToCacheScript}";
       auto-optimise-store = false;
     };
   };


### PR DESCRIPTION
## Summary
- Moves the binary cache post-build-hook from shared `nix/config.nix` to `lenovo-tablet.nix`
- The other two machines are used for work/client projects and shouldn't push every build to the personal cache
- All machines still fetch from the cache (substituters remain in shared config)

## Test plan
- [ ] `nixos-rebuild switch` on lenovo-tablet still pushes builds to cache
- [ ] Other machines no longer have the post-build-hook set

🤖 Generated with [Claude Code](https://claude.com/claude-code)