### PR TITLE
Skip cache.nixos.org paths before pushing to binary cache

### DIFF
--- a/lenovo-tablet.nix
+++ b/lenovo-tablet.nix
@@ -424,10 +424,13 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
         mv "$QUEUE" "$WORK"
 
+        # Dedup before any IO
+        DEDUPED=$(sort -u "$WORK" | grep -v '^$')
+        rm -f "$WORK"
+
         export NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new"
 
-        while IFS= read -r path; do
-          [ -z "$path" ] && continue
+        echo "$DEDUPED" | while IFS= read -r path; do
           HASH=$(basename "$path" | cut -d- -f1)
           if ${pkgs.curl}/bin/curl -sf "https://cache.nixos.org/$HASH.narinfo" > /dev/null 2>&1; then
             echo "skipping (on cache.nixos.org): $path" >&2
@@ -436,9 +439,7 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
           echo "pushing: $path" >&2
           ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org $path 2>&1 || \
             echo "WARNING: failed to push $path" >&2
-        done < "$WORK"
-
-        rm -f "$WORK"
+        done
       '';
     };
   };

--- a/lenovo-tablet.nix
+++ b/lenovo-tablet.nix
@@ -428,6 +428,11 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
         while IFS= read -r path; do
           [ -z "$path" ] && continue
+          HASH=$(basename "$path" | cut -d- -f1)
+          if ${pkgs.curl}/bin/curl -sf "https://cache.nixos.org/$HASH.narinfo" > /dev/null 2>&1; then
+            echo "skipping (on cache.nixos.org): $path" >&2
+            continue
+          fi
           echo "pushing: $path" >&2
           ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org $path 2>&1 || \
             echo "WARNING: failed to push $path" >&2

--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -119,32 +119,38 @@ let
       exit 1
     fi
 
-    export NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new"
-
+    # Collect all paths first
+    ALL_PATHS=""
     for arg in "$@"; do
       if [ -e /nix/store/"$(basename "$arg")" ] || echo "$arg" | grep -q '^/nix/store/'; then
-        echo "Pushing closure of store path: $arg" >&2
-        for path in $(${pkgs.nix}/bin/nix-store -qR "$arg"); do
-          ${nixosCacheCheck}
-          echo "pushing: $path" >&2
-          ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org "$path" || \
-            echo "WARNING: failed to push $path" >&2
-        done
+        echo "Collecting closure of store path: $arg" >&2
+        ALL_PATHS="$ALL_PATHS $(${pkgs.nix}/bin/nix-store -qR "$arg")"
       else
         echo "Instantiating: $arg" >&2
         DRV=$(${pkgs.nix}/bin/nix-instantiate "$arg")
         echo "Collecting realized build inputs from: $DRV" >&2
         for inputDrv in $(${pkgs.nix}/bin/nix-store -qR "$DRV" | grep '\.drv$'); do
-          for path in $(${pkgs.nix}/bin/nix-store -q --outputs "$inputDrv"); do
-            if [ -e "$path" ]; then
-              ${nixosCacheCheck}
-              echo "pushing: $path" >&2
-              ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org "$path" || \
-                echo "WARNING: failed to push $path" >&2
+          for out in $(${pkgs.nix}/bin/nix-store -q --outputs "$inputDrv"); do
+            if [ -e "$out" ]; then
+              ALL_PATHS="$ALL_PATHS $out"
             fi
           done
         done
       fi
+    done
+
+    # Dedup before any IO
+    DEDUPED=$(echo "$ALL_PATHS" | tr ' ' '\n' | sort -u | grep '^/nix/store/')
+    COUNT=$(echo "$DEDUPED" | wc -l)
+    echo "Pushing $COUNT unique paths (after dedup)" >&2
+
+    export NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new"
+
+    echo "$DEDUPED" | while IFS= read -r path; do
+      ${nixosCacheCheck}
+      echo "pushing: $path" >&2
+      ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org "$path" || \
+        echo "WARNING: failed to push $path" >&2
     done
     echo "Done" >&2
   '';

--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -101,6 +101,15 @@ let
     ${pkgs.piper-tts}/bin/piper -m ${piper-amy-voice}/en/en_US/amy/medium/en_US-amy-medium.onnx "$@"
   '';
 
+  # Skip paths already on the community cache
+  nixosCacheCheck = ''
+    HASH=$(basename "$path" | cut -d- -f1)
+    if ${pkgs.curl}/bin/curl -sf "https://cache.nixos.org/$HASH.narinfo" > /dev/null 2>&1; then
+      echo "skipping (on cache.nixos.org): $path" >&2
+      continue
+    fi
+  '';
+
   # Push full build closures (including build-time deps like cross-GHC)
   # to the binary cache on videocut.org
   push-jappie = pkgs.writeShellScriptBin "push-jappie" ''
@@ -109,27 +118,32 @@ let
       echo "Usage: push-jappie <nix-file-or-store-path> [nix-file...]" >&2
       exit 1
     fi
+
+    export NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new"
+
     for arg in "$@"; do
       if [ -e /nix/store/"$(basename "$arg")" ] || echo "$arg" | grep -q '^/nix/store/'; then
         echo "Pushing closure of store path: $arg" >&2
-        ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org \
-          $(${pkgs.nix}/bin/nix-store -qR "$arg")
+        for path in $(${pkgs.nix}/bin/nix-store -qR "$arg"); do
+          ${nixosCacheCheck}
+          echo "pushing: $path" >&2
+          ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org "$path" || \
+            echo "WARNING: failed to push $path" >&2
+        done
       else
         echo "Instantiating: $arg" >&2
         DRV=$(${pkgs.nix}/bin/nix-instantiate "$arg")
         echo "Collecting realized build inputs from: $DRV" >&2
-        PATHS=""
         for inputDrv in $(${pkgs.nix}/bin/nix-store -qR "$DRV" | grep '\.drv$'); do
-          for out in $(${pkgs.nix}/bin/nix-store -q --outputs "$inputDrv"); do
-            if [ -e "$out" ]; then
-              PATHS="$PATHS $out"
+          for path in $(${pkgs.nix}/bin/nix-store -q --outputs "$inputDrv"); do
+            if [ -e "$path" ]; then
+              ${nixosCacheCheck}
+              echo "pushing: $path" >&2
+              ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org "$path" || \
+                echo "WARNING: failed to push $path" >&2
             fi
           done
         done
-        DEDUPED=$(echo "$PATHS" | tr ' ' '\n' | sort -u | grep '^/nix/store/')
-        COUNT=$(echo "$DEDUPED" | wc -l)
-        echo "Pushing $COUNT paths to binary cache" >&2
-        echo "$DEDUPED" | xargs ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org
       fi
     done
     echo "Done" >&2


### PR DESCRIPTION
## Summary
- Before pushing each store path, checks `https://cache.nixos.org/<hash>.narinfo`
- If the community cache already has it, skips the push
- Applied to both the async drain service (lenovo-tablet) and `push-jappie`
- Saves disk space on videocut.org by not duplicating standard nixpkgs outputs

## Test plan
- [ ] `journalctl -u nix-cache-push` shows "skipping (on cache.nixos.org)" for common paths
- [ ] Custom builds (haskell packages, cross-GHC) still get pushed
- [ ] `push-jappie` skips community-cached paths and pushes the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)