### PR TITLE
Expand runtime closures before cache check

### DIFF
--- a/lenovo-tablet.nix
+++ b/lenovo-tablet.nix
@@ -424,9 +424,17 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
         mv "$QUEUE" "$WORK"
 
-        # Dedup before any IO
-        DEDUPED=$(sort -u "$WORK" | grep -v '^$')
+        # Expand runtime closures so deps are also checked
+        ALL_CLOSURE=""
+        while IFS= read -r path; do
+          [ -z "$path" ] && continue
+          ALL_CLOSURE="$ALL_CLOSURE
+$(${pkgs.nix}/bin/nix-store -qR "$path" 2>/dev/null || true)"
+        done < "$WORK"
         rm -f "$WORK"
+
+        # Dedup before any IO
+        DEDUPED=$(echo "$ALL_CLOSURE" | sort -u | grep '^/nix/store/')
 
         export NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new"
 

--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -119,7 +119,7 @@ let
       exit 1
     fi
 
-    # Collect all paths first
+    # Collect all paths first, expanding runtime closures
     ALL_PATHS=""
     for arg in "$@"; do
       if [ -e /nix/store/"$(basename "$arg")" ] || echo "$arg" | grep -q '^/nix/store/'; then
@@ -132,7 +132,7 @@ let
         for inputDrv in $(${pkgs.nix}/bin/nix-store -qR "$DRV" | grep '\.drv$'); do
           for out in $(${pkgs.nix}/bin/nix-store -q --outputs "$inputDrv"); do
             if [ -e "$out" ]; then
-              ALL_PATHS="$ALL_PATHS $out"
+              ALL_PATHS="$ALL_PATHS $(${pkgs.nix}/bin/nix-store -qR "$out")"
             fi
           done
         done


### PR DESCRIPTION
## Summary
- `nix copy` pushes the full closure, so checking only the top-level path misses runtime deps like `python3`
- Now both the drain service and `push-jappie` expand every path with `nix-store -qR` before dedup and cache.nixos.org checking
- Each individual runtime dep gets checked, preventing standard nixpkgs paths from being pushed to videocut.org

## Test plan
- [ ] `journalctl -u nix-cache-push` shows "skipping (on cache.nixos.org)" for standard deps like python3, glibc, etc.
- [ ] Only custom/non-cached paths get pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)