### PR TITLE
Fix push-jappie for multi-derivation nix files

### DIFF
--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -127,9 +127,9 @@ let
         ALL_PATHS="$ALL_PATHS $(${pkgs.nix}/bin/nix-store -qR "$arg")"
       else
         echo "Instantiating: $arg" >&2
-        DRV=$(${pkgs.nix}/bin/nix-instantiate "$arg")
-        echo "Collecting realized build inputs from: $DRV" >&2
-        for inputDrv in $(${pkgs.nix}/bin/nix-store -qR "$DRV" | grep '\.drv$'); do
+        DRVS=$(${pkgs.nix}/bin/nix-instantiate "$arg")
+        echo "Collecting realized build inputs from: $DRVS" >&2
+        for inputDrv in $(echo "$DRVS" | xargs ${pkgs.nix}/bin/nix-store -qR | grep '\.drv$'); do
           for out in $(${pkgs.nix}/bin/nix-store -q --outputs "$inputDrv"); do
             if [ -e "$out" ]; then
               ALL_PATHS="$ALL_PATHS $(${pkgs.nix}/bin/nix-store -qR "$out")"


### PR DESCRIPTION
## Summary
- `nix-instantiate` on files like `ci.nix` returns multiple `.drv` paths
- The old code stored them in a single variable, embedding newlines that corrupted the store path argument
- Now passes all drvs to `nix-store -qR` via `xargs`

## Test plan
- [ ] `push-jappie nix/ci.nix` works for prrrrrrrrr (which has multi-output ci.nix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)