### PR TITLE
Add bootable NixOS ISO with minimal sway environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,10 @@
 let
   sources = import ./npins;
   evalConfig = import (sources.nixpkgs + "/nixos/lib/eval-config.nix");
+  isoConfig = evalConfig {
+    system = "x86_64-linux";
+    modules = [ ./iso.nix ];
+  };
 in
 {
   work-machine = evalConfig {
@@ -15,4 +19,6 @@ in
     system = "x86_64-linux";
     modules = [ ./lenovo-tablet.nix ];
   };
+  iso = isoConfig;
+  isoImage = isoConfig.config.system.build.isoImage;
 }

--- a/iso.nix
+++ b/iso.nix
@@ -1,0 +1,51 @@
+# Bootable NixOS live ISO with minimal sway environment.
+# Uses installation-cd-minimal.nix — much smaller than the Plasma6 variant.
+# Includes emacs, CLI tools, sway, foot, waybar — no KDE/heavy desktop bloat.
+#
+# Build: nix-build default.nix -A isoImage
+# Test:  qemu-system-x86_64 -m 4G -cdrom result/iso/jappie-os-live.iso -enable-kvm
+
+{ pkgs, lib, modulesPath, ... }:
+{
+  imports = [
+    (modulesPath + "/installer/cd-dvd/installation-cd-minimal.nix")
+    ./emacs
+    ./nix/config.nix
+    ./nix/base-env.nix
+    ./nix/base-services.nix
+  ];
+
+  # Sway-only live environment (no Plasma6, no sddm)
+  # ISO profile handles display manager
+
+  image.fileName = "jappie-os-live.iso";
+  isoImage = {
+    volumeID = "JAPPIEOS";
+    contents = [{ source = ./.; target = "/linux-config"; }];
+  };
+
+  networking = {
+    hostName = "jappie-os-live";
+    networkmanager.enable = true;
+  };
+
+  console.keyMap = "us";
+  i18n = {
+    defaultLocale = "nl_NL.UTF-8";
+    supportedLocales = [ "en_US.UTF-8/UTF-8" "nl_NL.UTF-8/UTF-8" ];
+  };
+  time.timeZone = "Europe/Amsterdam";
+
+  users.users.jappie = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" "video" "audio" "networkmanager" ];
+    initialHashedPassword = "";
+    home = "/home/jappie";
+    uid = 1000;
+  };
+
+  hardware.graphics.enable = true;
+  hardware.bluetooth.enable = true;
+
+  system.stateVersion = "25.05";
+}

--- a/nix/base-env.nix
+++ b/nix/base-env.nix
@@ -1,0 +1,620 @@
+# Base environment shared between all machines including live ISO.
+# Contains CLI tools, dev tools, haskell/nix tools, media CLI,
+# fonts, theming, foot terminal, waybar, custom scripts.
+#
+# Heavy/desktop packages (KDE, blender, krita, gimp, libreoffice,
+# steam, games, redundant browsers, etc.) stay in environment.nix.
+
+{ pkgs, ... }:
+let
+  sources = import ../npins;
+
+  # unfuck the flake, unsubscribe from the mental health workshop.
+  fuckingFlake = outPath: (import sources.flake-compat { src = outPath; }).outputs;
+
+  # Forces wayland,
+  # also enables touch support
+  tabletSafe =
+    pkg:
+    pkgs.symlinkJoin {
+      name = "${pkg.pname or "app"}-tablet-safe";
+      paths = [ pkg ];
+      buildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        # We find the main binary and wrap it with our safety flags
+        wrapProgram $out/bin/${pkg.pname or (builtins.parseDrvName pkg.name).name} \
+          --set MOZ_USE_XINPUT2 "1" \
+          --set MOZ_ENABLE_WAYLAND "1"
+      '';
+    };
+
+  agenix = fuckingFlake sources.agenix.outPath;
+
+  unstable = import sources.unstable { };
+  unstable2 = import sources.unstable2 { };
+  unstable3 = import sources.unstable3 { };
+
+  hostdir = pkgs.writeShellScriptBin "hostdir" ''
+    ${pkgs.lib.getExe pkgs.python3} -m http.server
+  '';
+
+  # phone makes pictures to big usually
+  # I need to track these often in a git repo and having it be bigger then 1meg is bad
+  resize-images = pkgs.writeShellScriptBin "resize-images" ''
+    set -xe
+    outfolder=/tmp/small
+    mkdir -p $outfolder
+    for i in `echo *.jpg`; do
+    ${pkgs.imagemagick}/bin/convert -resize 50% -quality 90 "$@" $i $outfolder/$i.small.jpg;
+    done
+    echo "wrote to "$outfolder
+  '';
+
+  nixos = pkgs.writeShellScriptBin "nixos" "${../scripts/rebuild.sh} $@";
+
+  # Me to the max
+  maxme = pkgs.writeShellScriptBin "maxme" ''emacsclient . &!'';
+
+  fuckdirenv = pkgs.writeShellScriptBin "fuckdirenv" ''fd -t d -IH direnv --exec rm -r'';
+
+  reload-emacs = pkgs.writeShellScriptBin "reload-emacs" ''
+    sudo nixos-rebuild switch && systemctl daemon-reload --user &&    systemctl restart emacs --user
+  '';
+
+  # cleans the stale sockets for emacs in case the emacs client isn't
+  # working with the window manager
+  clean-emacs = pkgs.writeShellScriptBin "clean-emacs" ''
+    systemctl --user stop emacs
+    rm -rf /tmp/emacs$(id -u)
+    rm -rf $XDG_RUNTIME_DIR/emacs
+    systemctl --user start emacs
+  '';
+
+  # a good workaround is worth a thousand poor fixes
+  start-ib = pkgs.writeShellScriptBin "start-ib" ''
+    xhost +
+    docker rm broker-client
+    docker run --name=broker-client -d -v /tmp/.X11-unix:/tmp/.X11-unix -it ib bash
+    docker exec -it broker-client tws
+  '';
+
+  # for whenever people think mac is hardcoded in hardware.
+  # succers.
+  change-mac = pkgs.writeShellScriptBin "change-mac" ''
+    pkill NetworkManager
+    ifconfig wlp1s0 down
+    macchanger -r wlp1s0
+    ifconfig wlp1s0 up
+    NetworkManager
+  '';
+
+  piper-amy-voice = pkgs.fetchgit {
+    url = "https://huggingface.co/rhasspy/piper-voices";
+    rev = "834f23262168a7e809179465e4113f23f5a7d1f7";
+    hash = "sha256-MKBOTTPy3WXUcKa+0+U7HOT5Nm/LuWVqCi7lTMIpo0Y=";
+    fetchLFS = true;
+    sparseCheckout = [
+      "en/en_US/amy/medium/en_US-amy-medium.onnx"
+      "en/en_US/amy/medium/en_US-amy-medium.onnx.json"
+    ];
+  };
+
+  piper = pkgs.writeShellScriptBin "piper" ''
+    ${pkgs.piper-tts}/bin/piper -m ${piper-amy-voice}/en/en_US/amy/medium/en_US-amy-medium.onnx "$@"
+  '';
+
+  # Skip paths already on the community cache
+  nixosCacheCheck = ''
+    HASH=$(basename "$path" | cut -d- -f1)
+    if ${pkgs.curl}/bin/curl -sf "https://cache.nixos.org/$HASH.narinfo" > /dev/null 2>&1; then
+      echo "skipping (on cache.nixos.org): $path" >&2
+      continue
+    fi
+  '';
+
+  # Push full build closures (including build-time deps like cross-GHC)
+  # to the binary cache on videocut.org
+  push-jappie = pkgs.writeShellScriptBin "push-jappie" ''
+    set -euf
+    if [ $# -eq 0 ]; then
+      echo "Usage: push-jappie <nix-file-or-store-path> [nix-file...]" >&2
+      exit 1
+    fi
+
+    # Collect all paths first, expanding runtime closures
+    ALL_PATHS=""
+    for arg in "$@"; do
+      if [ -e /nix/store/"$(basename "$arg")" ] || echo "$arg" | grep -q '^/nix/store/'; then
+        echo "Collecting closure of store path: $arg" >&2
+        ALL_PATHS="$ALL_PATHS $(${pkgs.nix}/bin/nix-store -qR "$arg")"
+      else
+        echo "Instantiating: $arg" >&2
+        DRVS=$(${pkgs.nix}/bin/nix-instantiate "$arg")
+        echo "Collecting realized build inputs from: $DRVS" >&2
+        for inputDrv in $(echo "$DRVS" | xargs ${pkgs.nix}/bin/nix-store -qR | grep '\.drv$'); do
+          for out in $(${pkgs.nix}/bin/nix-store -q --outputs "$inputDrv"); do
+            if [ -e "$out" ]; then
+              ALL_PATHS="$ALL_PATHS $(${pkgs.nix}/bin/nix-store -qR "$out")"
+            fi
+          done
+        done
+      fi
+    done
+
+    # Dedup before any IO
+    DEDUPED=$(echo "$ALL_PATHS" | tr ' ' '\n' | sort -u | grep '^/nix/store/')
+    COUNT=$(echo "$DEDUPED" | wc -l)
+    echo "Pushing $COUNT unique paths (after dedup)" >&2
+
+    export NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new"
+
+    echo "$DEDUPED" | while IFS= read -r path; do
+      ${nixosCacheCheck}
+      echo "pushing: $path" >&2
+      ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org "$path" || \
+        echo "WARNING: failed to push $path" >&2
+    done
+    echo "Done" >&2
+  '';
+
+in
+{
+
+  environment = {
+    systemPackages = with pkgs.xfce // pkgs; [
+      (fuckingFlake sources.Hexecute).packages.${pkgs.stdenv.hostPlatform.system}.default
+      gsimplecal
+      clean-emacs
+      cliphist
+      wl-clipboard # clipboard for wayland?
+      wtype # xdotool for wayland
+      pkgs.grim  # The screenshot tool
+      pkgs.slurp # The region selector
+
+      protobuf
+      qemu_full
+      # for those sweet global installs
+      unstable.nodePackages.pnpm
+      nodejs
+      terraform
+      unstable2.openapi-generator-cli
+      qrencode
+      nixos
+      push-jappie
+
+      wvkbd # onscreen keyboard
+
+      # gnome settings
+      glib
+      dconf
+
+      blesh
+      atuin
+      fuckdirenv
+      mosquitto
+      npins
+
+      nix-output-monitor # pretty nix graph
+
+      xfce4-terminal
+
+      yt-dlp
+      rofi
+      unstable2.devenv
+      pkgs.haskellPackages.greenclip
+      unstable.nodejs_20 # the one in main is broken, segfautls
+      unstable3.postgresql
+      audacious
+      xclip
+      filezilla
+      slop
+      xorg.xhost
+      unzip
+      mesa
+      idris
+      pciutils
+      gptfdisk # gdisk
+      clang-tools # clang-format
+      lz4
+      yt-dlp
+      pkgs.haskellPackages.fourmolu
+      bluez
+      awscli2
+
+      ed # ed is the standard editor!
+
+      electrum # peeps ask me to buy crypto for them :s
+
+      # eg use it to explore dependencies on flakes,
+      # for example: --derivation '.#trilateration'
+      nix-tree
+
+      # https://superuser.com/questions/171195/how-to-check-the-health-of-a-hard-drive
+      smartmontools
+
+      # gtk-vnc # screen sharing for linux
+      x2vnc
+      hugin # panorama sticther
+
+      agenix.packages.x86_64-linux.agenix
+
+      # arion, eg docker-compose for nix
+      arion
+      docker-client
+      docker-compose
+
+      neomutt
+      miraclecast
+      gnome-network-displays
+
+      iw # fav around with wireless networks https://gitlab.gnome.org/GNOME/gnome-network-displays/-/issues/64
+
+      postman
+
+      binutils # eg nm and other lowlevel cruft
+      radare2
+
+      tldr
+
+      # devpackeges.haskellPackages.cut-the-crap
+      # pkgs.haskellPackages.cut-the-crap
+      lsof
+      ffmpeg
+      gromit-mpx # draw on screen
+      usbutils
+      # pkgsUnstable.boomer
+      gcc
+      scrcpy
+      audacity
+      xss-lock
+      i3lock
+      i3status
+      nixpkgs-fmt
+      mpv # mplayer
+      starship
+      openssl
+      reload-emacs
+      start-ib
+      cabal2nix
+      maxme
+      zip
+      # ib-tws
+      resize-images
+      lz4
+
+      hyperfine # better time command
+
+      tldr # better man
+
+      ormolu
+
+      fsv # browse files like a chad
+      hostdir
+
+      mariadb
+
+      macchanger # change mac address
+      change-mac
+      /*
+        $ sudo service network-manager stop
+        $ ifconfig wlp2s0b1 down
+        $ sudo macchanger -r wlp2s0b1
+        $ sudo service network-manager start
+        $ sudo ifconfig wlp2s0b1 up
+      */
+
+      hardinfo2 # https://askubuntu.com/questions/179958/how-do-i-find-out-my-motherboard-model
+      dmidecode
+
+      pv # cat with progress bar
+
+      nmap
+
+      # pkgsUnstable.ib-tws # intereactive brokers trader workstation
+      fcitx5
+      zoxide
+
+      # lm-sensors
+      fd # better find, 50% shorter command!
+      # pgcli # better postgres cli client
+      pgcli # better postgres cli client
+      unrar
+      sshuttle
+      linux-firmware
+      gource
+      p7zip
+      bc # random calcualtions
+      thunar
+      inkscape # gotta make that artwork for site etc
+      gnupg # for private keys
+
+      git-crypt # pgp based encryption for git repos (the dream is real)
+      jq # deal with json on commandline
+      sqlite-interactive # hack nixops
+      curl
+      neovim # because emacs never breaks
+      networkmanagerapplet # make wifi clickable
+      git
+      imagemagick
+      keepassxc # to open my passwords
+      tree # sl
+
+      # theme shit
+      blackbird
+      lxappearance # theme, adwaita-dark works for gtk3, gtk2 and qt5.
+      libsForQt5.qt5ct
+
+      mesa-demos # glxgears
+      btop
+
+      zoxide # fasd # fasd died on me for some reason # try zoxide in future, it's rust based and active (this one is dead)
+      fzf # used by zoxide
+
+      wdisplays # repair geoemtry of external monitors in wayland
+      /* TO MAKE IT PERMENANT
+      swaymsg -t get_outputs
+
+      modify sway/config with:
+      output <name> resolution <width>x<height> position <x>,<y>
+      for example:
+
+# beamer setup wooo
+output DP-1 resolution 1280x720 position 0,0
+output eDP-1 resolution 2880x1800 position 0,720
+
+# and so I forget the name of wdisplays again hahaha
+# I shall be the most useless software grifter this planet ever saw and shall see.
+      */
+
+
+      cowsay
+      fortune
+      vlc
+      (tabletSafe firefox)
+      blueman
+
+      pavucontrol
+      gparted # partitiioning for dummies, like me
+
+      (tabletSafe thunderbird) # some day I'll use emacs for this
+      # the spell to make openvpn work:   nmcli connection modify jappie vpn.data "key = /home/jappie/openvpn/website/jappie.key, ca = /home/jappie/openvpn/website/ca.crt, dev = tun, cert = /home/jappie/openvpn/website/jappie.crt, ns-cert-type = server, cert-pass-flags = 0, comp-lzo = adaptive, remote = jappieklooster.nl:1194, connection-type = tls"
+      # from https://github.com/NixOS/nixpkgs/issues/30235
+      openvpn # piratebay access
+
+      gnumake # handy for adhoc configs, https://github.com/NixOS/nixpkgs/issues/17293
+      # fbreader # read books # TODO broken?
+      qpdfview
+      tcpdump
+      ntfs3g
+      qdirstat
+      feh
+      dnsutils
+
+      espeak
+      piper # piper-tts wrapper with Amy voice model
+
+      pandoc
+
+      tmate
+      cachix
+
+      anki
+      cloc
+      lshw # list hardware
+      pkgs.xorg.xev # monitor x events
+
+      direnv # https://direnv.net/
+      nix-direnv
+
+      # deal with slow notifications
+      dunst
+      libnotify
+    ];
+    shellAliases = {
+      nix = "nom";
+      nix-shell = "nom-shell";
+      niixos-rebuild = "nixos-rebuild";
+      nixos-rebuild = "nixos-rebuild --no-reexec";
+      nix-build = "nom-build";
+      niix = "${pkgs.nix}/bin/nix -v --fallback";
+      niix-shell = "${pkgs.nix}/bin/nix-shell -v --fallback";
+      niix-build = "${pkgs.nix}/bin/nix-build -v --fallback";
+      vim = "nvim";
+      cp = "cp --reflink=auto"; # btrfs shine
+      ssh = "ssh -C"; # why is this not default?
+      bc = "bc -l"; # fix scale
+    };
+    variables = {
+      LESS = "-F -X -R";
+    };
+    pathsToLink = [
+      "/share/nix-direnv"
+    ];
+
+    # set theme, make font also bigger by default as we've
+    # high res screen
+    etc."xdg/gtk-2.0/gtkrc".text = ''
+      [Settings]
+      gtk-theme-name="Adwaita"
+      gtk-font-name = Noto Sans 18
+    '';
+
+    etc."xdg/gtk-3.0/settings.ini".text = ''
+      [Settings]
+      gtk-theme-name=Adwaita
+      gtk-font-name = Noto Sans 18
+    '';
+
+    variables.QT_QPA_PLATFORMTHEME = "qt5ct";
+
+    # make dunst less ug ug
+    etc."dunst/dunstrc".text = ''
+      [global]
+          ### Serif Style ###
+          # 'Georgia' is high-legibility. If you want a more
+          # classic look, you can use 'Times New Roman'.
+          font = Georgia 18
+
+          format = "<b>%s</b>\n%b"
+          width = 600
+          height = 300
+          offset = 30x50
+          origin = top-right
+          padding = 16
+          horizontal_padding = 16
+          frame_width = 3
+          frame_color = "#F92672" # Molokai Pink
+          separator_color = frame
+
+          # Progress bar
+          progress_bar = true
+          progress_bar_height = 10
+          progress_bar_frame_width = 1
+
+      [urgency_low]
+          background = "#1B1D1E"
+          foreground = "#F8F8F2"
+          frame_color = "#A6E22E" # Molokai Green
+          timeout = 10
+
+      [urgency_normal]
+          background = "#1B1D1E"
+          foreground = "#F8F8F2"
+          frame_color = "#F92672" # Molokai Pink
+          timeout = 15
+
+      [urgency_critical]
+          background = "#1B1D1E"
+          foreground = "#F8F8F2"
+          frame_color = "#FD971F" # Molokai Orange
+          timeout = 0
+    '';
+
+  };
+
+  # fix gnome termianl fonts
+  services.xserver.displayManager.sessionCommands = ''
+    ${pkgs.glib}/bin/gsettings set org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/ use-system-font false
+    ${pkgs.glib}/bin/gsettings set org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/ font 'Fira Code 18'
+  '';
+
+  fonts = {
+    enableDefaultPackages = true;
+    packages = with pkgs; [
+      fira-code
+      fira-code-symbols
+      inconsolata
+      ubuntu-classic
+      corefonts
+      font-awesome_4
+      font-awesome_5
+      siji
+      jetbrains-mono
+      noto-fonts-cjk-sans
+      ipaexfont
+      helvetica-neue-lt-std
+    ];
+    fontconfig = {
+      defaultFonts = {
+        # we need to set in in qt5ct as well.
+        sansSerif = [ "Noto Sans" ];
+        monospace = [ "Fira Code" ];
+      };
+    };
+  };
+
+  services.dbus.packages = [ pkgs.dconf ]; # Ensure dconf has dbus access
+  programs = {
+    # Force GNOME Terminal to use Fira Code 12
+    dconf.enable = true;
+
+    xfconf.enable = true; # allow configuring thunar
+    # can find them here
+    # https://github.com/NixOS/nixpkgs/tree/master/pkgs/desktops/xfce/thunar-plugins
+    # some aren't packaged yet:
+    # https://docs.xfce.org/xfce/thunar/start#thunar_plugins
+    # I think samba would be rad.
+    thunar.plugins = with pkgs.xfce; [
+      thunar-archive-plugin
+      thunar-volman
+      thunar-vcs-plugin
+      thunar-media-tags-plugin
+    ];
+
+    gnupg.agent = {
+      enable = true;
+      enableSSHSupport = true;
+    };
+    vim.defaultEditor = true;
+    vim.enable = true;
+    adb.enable = true;
+    light.enable = true;
+    foot = {
+      enable = true;
+      theme = "molokai"; # Or any base16 theme
+      settings = {
+        scrollback = {
+          lines = 100000;
+        };
+        key-bindings = {
+          "clipboard-paste" = "Control+v";
+        };
+      };
+    };
+
+    waybar = {
+      enable = true;
+      systemd.target = "sway-session.target";
+    };
+  };
+
+  nixpkgs.config = {
+    allowUnfree = true; # I'm horrible, nvidia sucks, TODO kill nvidia
+    packageeverrides = pkgs: {
+      neovim = pkgs.neovim.override {
+        configure = {
+          customRC = ''
+            set syntax=on
+            set autoindent
+            set autowrite
+            set smartcase
+            set showmode
+            set nowrap
+            set number
+            set nocompatible
+            set tw=80
+            set smarttab
+            set smartindent
+            set incsearch
+            set mouse=a
+            set history=10000
+            set completeopt=menuone,menu,longest
+            set wildignore+=*\\tmp\\*,*.swp,*.swo,*.git
+            set wildmode=longest,list,full
+            set wildmenu
+            set t_Co=512
+            set cmdheight=1
+            set expandtab
+            set clipboard=unnamedplus
+            autocmd FileType haskell setlocal sw=4 sts=4 et
+          '';
+          packages.neovim2 = with pkgs.vimPlugins; {
+
+            start = [
+              tabular
+              syntastic
+              vim-nix
+              neomake
+              ctrlp
+              neoformat
+              gitgutter
+            ];
+            opt = [ ];
+          };
+        };
+      };
+
+    };
+  };
+
+}

--- a/nix/base-services.nix
+++ b/nix/base-services.nix
@@ -1,0 +1,98 @@
+# Base services shared between all machines including live ISO.
+# These are background running programs that make sense everywhere.
+# Machine-specific and persistent services (openssh, syncthing, postgresql, etc.)
+# stay in services.nix.
+
+{ pkgs, ... }:
+{
+  # stops ff and thunderbird from freezing on notifications with i3
+  systemd.user.services.dunst = {
+    description = "Dunst notification daemon";
+    after = [ "graphical-session-pre.target" ];
+
+    partOf = [ "sway-session.target" ];  # Stops dunst if sway-session stops
+    wantedBy = [ "sway-session.target" ]; # Starts dunst when sway-session starts
+
+    unitConfig = {
+      ConditionEnvironment = "WAYLAND_DISPLAY";
+    };
+    serviceConfig = {
+      Type = "dbus";
+      BusName = "org.freedesktop.Notifications";
+      ExecStart = "${pkgs.dunst}/bin/dunst -config /etc/dunst/dunstrc";
+      Restart = "always";
+      RestartSec = 2;
+       };
+  };
+  programs.sway.enable = true;
+
+  services = {
+
+    pipewire = {
+      enable = true;
+      alsa.enable = true;
+      alsa.support32Bit = true;
+      pulse.enable = true;
+    };
+
+    journald.extraConfig = ''
+      SystemMaxUse=50M
+      RuntimeMaxUse=50M
+    '';
+    gvfs.enable = true; # Mount, trash, and other functionalities
+    tumbler.enable = true; # Thumbnail support for images
+
+    libinput = {
+      enable = true;
+      touchpad = {
+        tapping = true;
+        disableWhileTyping = true;
+      };
+    };
+
+    xserver = {
+      xkb = {
+        layout = "us";
+        options = "caps:swapescape";
+      };
+
+      autorun = true; # disable on troubles
+      windowManager.i3.enable = true;
+      windowManager.i3.extraPackages = [ pkgs.adwaita-qt ];
+      windowManager.i3.extraSessionCommands = ''
+        sleep 1;
+        ${pkgs.xorg.xmodmap}/bin/xmodmap ~/.Xmodmap
+      '';
+
+      enable = true;
+    };
+
+    redshift = {
+      enable = true;
+    };
+
+    # https://github.com/rfjakob/earlyoom
+    earlyoom.enable = true; # kills big processes better then kernel
+
+    # the new compoton
+    # https://forum.mxlinux.org/viewtopic.php?p=549425
+    picom = {
+      enable = true;
+      vSync = true;
+      backend = "glx"; # Or "xr_glx_hybrid" if glx freezes
+      inactiveOpacity = 0.925;
+      fadeSteps = [
+        0.04
+        0.04
+      ];
+      settings = {
+        # Crucial for preventing the "freeze" on AMD mobile
+        use-damage = false;
+        xrender-sync-fence = true;
+      };
+    };
+
+  };
+
+  location.provider = "geoclue2";
+}

--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -2,13 +2,13 @@
 # this basically tells what programs are available, acknowledging
 # I want the same programs on all machine, although it'll be a
 # little wasteful, saves me having to find and install stuff
+#
+# Base environment (CLI tools, dev tools, fonts, theming, etc.)
+# is in base-env.nix. This file adds heavy desktop packages on top.
 
 { pkgs, ... }:
 let
   sources = import ../npins;
-
-  # unfuck the flake, unsubscribe from the mental health workshop.
-  fuckingFlake = outPath: (import sources.flake-compat { src = outPath; }).outputs;
 
   # Forces wayland,
   # also enables touch support
@@ -26,579 +26,51 @@ let
       '';
     };
 
-  agenix = fuckingFlake sources.agenix.outPath;
-
-  unstable = import sources.unstable { };
-  unstable2 = import sources.unstable2 { };
-  unstable3 = import sources.unstable3 { };
-
-  hostdir = pkgs.writeShellScriptBin "hostdir" ''
-    ${pkgs.lib.getExe pkgs.python3} -m http.server
-  '';
-
-  # phone makes pictures to big usually
-  # I need to track these often in a git repo and having it be bigger then 1meg is bad
-  resize-images = pkgs.writeShellScriptBin "resize-images" ''
-    set -xe
-    outfolder=/tmp/small
-    mkdir -p $outfolder
-    for i in `echo *.jpg`; do
-    ${pkgs.imagemagick}/bin/convert -resize 50% -quality 90 "$@" $i $outfolder/$i.small.jpg;
-    done
-    echo "wrote to "$outfolder
-  '';
-
-  nixos = pkgs.writeShellScriptBin "nixos" "${../scripts/rebuild.sh} $@";
-
-  # Me to the max
-  maxme = pkgs.writeShellScriptBin "maxme" ''emacsclient . &!'';
-
-  fuckdirenv = pkgs.writeShellScriptBin "fuckdirenv" ''fd -t d -IH direnv --exec rm -r'';
-
-  reload-emacs = pkgs.writeShellScriptBin "reload-emacs" ''
-    sudo nixos-rebuild switch && systemctl daemon-reload --user &&    systemctl restart emacs --user
-  '';
-
-  # cleans the stale sockets for emacs in case the emacs client isn't
-  # working with the window manager
-  clean-emacs = pkgs.writeShellScriptBin "clean-emacs" ''
-    systemctl --user stop emacs
-    rm -rf /tmp/emacs$(id -u)
-    rm -rf $XDG_RUNTIME_DIR/emacs
-    systemctl --user start emacs
-  '';
-
-  # a good workaround is worth a thousand poor fixes
-  start-ib = pkgs.writeShellScriptBin "start-ib" ''
-    xhost +
-    docker rm broker-client
-    docker run --name=broker-client -d -v /tmp/.X11-unix:/tmp/.X11-unix -it ib bash
-    docker exec -it broker-client tws
-  '';
-
-  # for whenever people think mac is hardcoded in hardware.
-  # succers.
-  change-mac = pkgs.writeShellScriptBin "change-mac" ''
-    pkill NetworkManager
-    ifconfig wlp1s0 down
-    macchanger -r wlp1s0
-    ifconfig wlp1s0 up
-    NetworkManager
-  '';
-
-  piper-amy-voice = pkgs.fetchgit {
-    url = "https://huggingface.co/rhasspy/piper-voices";
-    rev = "834f23262168a7e809179465e4113f23f5a7d1f7";
-    hash = "sha256-MKBOTTPy3WXUcKa+0+U7HOT5Nm/LuWVqCi7lTMIpo0Y=";
-    fetchLFS = true;
-    sparseCheckout = [
-      "en/en_US/amy/medium/en_US-amy-medium.onnx"
-      "en/en_US/amy/medium/en_US-amy-medium.onnx.json"
-    ];
-  };
-
-  piper = pkgs.writeShellScriptBin "piper" ''
-    ${pkgs.piper-tts}/bin/piper -m ${piper-amy-voice}/en/en_US/amy/medium/en_US-amy-medium.onnx "$@"
-  '';
-
-  # Skip paths already on the community cache
-  nixosCacheCheck = ''
-    HASH=$(basename "$path" | cut -d- -f1)
-    if ${pkgs.curl}/bin/curl -sf "https://cache.nixos.org/$HASH.narinfo" > /dev/null 2>&1; then
-      echo "skipping (on cache.nixos.org): $path" >&2
-      continue
-    fi
-  '';
-
-  # Push full build closures (including build-time deps like cross-GHC)
-  # to the binary cache on videocut.org
-  push-jappie = pkgs.writeShellScriptBin "push-jappie" ''
-    set -euf
-    if [ $# -eq 0 ]; then
-      echo "Usage: push-jappie <nix-file-or-store-path> [nix-file...]" >&2
-      exit 1
-    fi
-
-    # Collect all paths first, expanding runtime closures
-    ALL_PATHS=""
-    for arg in "$@"; do
-      if [ -e /nix/store/"$(basename "$arg")" ] || echo "$arg" | grep -q '^/nix/store/'; then
-        echo "Collecting closure of store path: $arg" >&2
-        ALL_PATHS="$ALL_PATHS $(${pkgs.nix}/bin/nix-store -qR "$arg")"
-      else
-        echo "Instantiating: $arg" >&2
-        DRVS=$(${pkgs.nix}/bin/nix-instantiate "$arg")
-        echo "Collecting realized build inputs from: $DRVS" >&2
-        for inputDrv in $(echo "$DRVS" | xargs ${pkgs.nix}/bin/nix-store -qR | grep '\.drv$'); do
-          for out in $(${pkgs.nix}/bin/nix-store -q --outputs "$inputDrv"); do
-            if [ -e "$out" ]; then
-              ALL_PATHS="$ALL_PATHS $(${pkgs.nix}/bin/nix-store -qR "$out")"
-            fi
-          done
-        done
-      fi
-    done
-
-    # Dedup before any IO
-    DEDUPED=$(echo "$ALL_PATHS" | tr ' ' '\n' | sort -u | grep '^/nix/store/')
-    COUNT=$(echo "$DEDUPED" | wc -l)
-    echo "Pushing $COUNT unique paths (after dedup)" >&2
-
-    export NIX_SSHOPTS="-i /home/jappie/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new"
-
-    echo "$DEDUPED" | while IFS= read -r path; do
-      ${nixosCacheCheck}
-      echo "pushing: $path" >&2
-      ${pkgs.nix}/bin/nix copy --to ssh-ng://root@videocut.org "$path" || \
-        echo "WARNING: failed to push $path" >&2
-    done
-    echo "Done" >&2
-  '';
-
 in
 {
-
-  environment = {
-    systemPackages = with pkgs.xfce // pkgs; [
-      (fuckingFlake sources.Hexecute).packages.${pkgs.stdenv.hostPlatform.system}.default
-      gsimplecal
-      qbittorrent # bittorent
-      clean-emacs
-      cliphist
-      wl-clipboard # clipboard for wayland?
-      wtype # xdotool for wayland
-      pkgs.grim  # The screenshot tool
-      pkgs.slurp # The region selector
-
-      protobuf
-      qemu_full
-      kdePackages.kdenlive
-      # for those sweet global installs
-      unstable.nodePackages.pnpm
-      nodejs
-      terraform
-      unstable2.openapi-generator-cli
-      qrencode
-      nixos
-      push-jappie
-
-      wvkbd # onscreen keyboard
-
-      # gnome settings
-      glib
-      dconf
-
-      blesh
-      atuin
-      openrct2
-      starsector
-      fuckdirenv
-      mosquitto
-      npins
-
-      nix-output-monitor # pretty nix graph
-
-      (tabletSafe tor-browser)
-      kdePackages.kdenlive
-      kdePackages.konsole
-      xfce4-terminal
-
-      yt-dlp
-      rofi
-      unstable2.devenv
-      pkgs.haskellPackages.greenclip
-      unstable.nodejs_20 # the one in main is broken, segfautls
-      unstable3.postgresql
-      audacious
-      xclip
-      filezilla
-      slop
-      xorg.xhost
-      unzip
-      krita
-      chatterino2 # TODO this doesn't work, missing xcb
-      blender
-      mesa
-      idris
-      pciutils
-      gptfdisk # gdisk
-      clang-tools # clang-format
-      lz4
-      yt-dlp
-      pkgs.haskellPackages.fourmolu
-      bluez
-      awscli2
-
-      ed # ed is the standard editor!
-
-      electrum # peeps ask me to buy crypto for them :s
-
-      # eg use it to explore dependencies on flakes,
-      # for example: --derivation '.#trilateration'
-      nix-tree
-
-      # https://superuser.com/questions/171195/how-to-check-the-health-of-a-hard-drive
-      smartmontools
-
-      # gtk-vnc # screen sharing for linux
-      x2vnc
-      hugin # panorama sticther
-
-      agenix.packages.x86_64-linux.agenix
-
-      # arion, eg docker-compose for nix
-      arion
-      docker-client
-      docker-compose
-
-      augustus
-      neomutt
-      miraclecast
-      gnome-network-displays
-
-      iw # fav around with wireless networks https://gitlab.gnome.org/GNOME/gnome-network-displays/-/issues/64
-
-      # eg final fantasy 7 is in ~/ff7
-      # press f4 to laod state
-      # f2 to save
-      (retroarch.withCores (libretro: [
-        # genesis-plus-gx
-        # snes9x
-        libretro.beetle-psx-hw
-      ]))
-      postman
-
-      binutils # eg nm and other lowlevel cruft
-      radare2
-
-      openttd
-      tldr
-      openra
-
-      # devpackeges.haskellPackages.cut-the-crap
-      # pkgs.haskellPackages.cut-the-crap
-      lsof
-      ffmpeg
-      gromit-mpx # draw on screen
-      usbutils
-      # pkgsUnstable.boomer
-      gcc
-      scrcpy
-      audacity
-      xss-lock
-      i3lock
-      i3status
-      nixpkgs-fmt
-      mpv # mplayer
-      kdePackages.ark
-      burpsuite
-      starship
-      openssl
-      reload-emacs
-      start-ib
-      cabal2nix
-      maxme
-      zip
-      # ib-tws
-      resize-images
-      lz4
-
-      hyperfine # better time command
-
-      tldr # better man
-
-      ormolu
-
-      fsv # browse files like a chad
-      hostdir
-
-      crawlTiles
-      mariadb
-      browsh # better browser, replaces elinks. # NB: leana agrees :):)
-
-      macchanger # change mac address
-      change-mac
-      /*
-        $ sudo service network-manager stop
-        $ ifconfig wlp2s0b1 down
-        $ sudo macchanger -r wlp2s0b1
-        $ sudo service network-manager start
-        $ sudo ifconfig wlp2s0b1 up
-      */
-
-      hardinfo2 # https://askubuntu.com/questions/179958/how-do-i-find-out-my-motherboard-model
-      dmidecode
-
-      pv # cat with progress bar
-
-      nmap
-
-      # pkgsUnstable.ib-tws # intereactive brokers trader workstation
-      fcitx5
-      zoxide
-
-      # lm-sensors
-      fd # better find, 50% shorter command!
-      # pgcli # better postgres cli client
-      pgcli # better postgres cli client
-      unrar
-      sshuttle
-      linux-firmware
-      gource
-      p7zip
-      steam
-      bc # random calcualtions
-      thunar
-      inkscape # gotta make that artwork for site etc
-      gnupg # for private keys
-
-      git-crypt # pgp based encryption for git repos (the dream is real)
-      jq # deal with json on commandline
-      sqlite-interactive # hack nixops
-      gimp # edit my screenshots
-      curl
-      neovim # because emacs never breaks
-      networkmanagerapplet # make wifi clickable
-      git
-      imagemagick
-      keepassxc # to open my passwords
-      tree # sl
-
-      # theme shit
-      blackbird
-      lxappearance # theme, adwaita-dark works for gtk3, gtk2 and qt5.
-      libsForQt5.qt5ct
-
-      mesa-demos # glxgears
-      btop
-
-      zoxide # fasd # fasd died on me for some reason # try zoxide in future, it's rust based and active (this one is dead)
-      fzf # used by zoxide
-
-      wdisplays # repair geoemtry of external monitors in wayland
-      /* TO MAKE IT PERMENANT
-      swaymsg -t get_outputs
-
-      modify sway/config with:
-      output <name> resolution <width>x<height> position <x>,<y>
-      for example:
-
-# beamer setup wooo
-output DP-1 resolution 1280x720 position 0,0
-output eDP-1 resolution 2880x1800 position 0,720
-
-# and so I forget the name of wdisplays again hahaha
-# I shall be the most useless software grifter this planet ever saw and shall see.
-      */
-
-
-      cowsay
-      fortune
-      vlc
-      (tabletSafe firefox)
-      blueman
-
-      chromium # NB: may also need to be wrapped by tablet safe
-      pavucontrol
-      gparted # partitiioning for dummies, like me
-
-      (tabletSafe thunderbird) # some day I'll use emacs for this
-      # the spell to make openvpn work:   nmcli connection modify jappie vpn.data "key = /home/jappie/openvpn/website/jappie.key, ca = /home/jappie/openvpn/website/ca.crt, dev = tun, cert = /home/jappie/openvpn/website/jappie.crt, ns-cert-type = server, cert-pass-flags = 0, comp-lzo = adaptive, remote = jappieklooster.nl:1194, connection-type = tls"
-      # from https://github.com/NixOS/nixpkgs/issues/30235
-      openvpn # piratebay access
-
-      # kdePackages.plasma-systemmonitor # monitor my system.. with graphs! (so I don't need to learn real skills) # disabled cuz it wants to build it, doesn't hit cache
-      kdePackages.plasma-systemmonitor # monitor my system.. with graphs! (so I don't need to learn real skills)
-      gnumake # handy for adhoc configs, https://github.com/NixOS/nixpkgs/issues/17293
-      # fbreader # read books # TODO broken?
-      libreoffice
-      qpdfview
-      tcpdump
-      ntfs3g
-      qdirstat
-      feh
-      dnsutils
-      zoom-us
-
-      espeak
-      piper # piper-tts wrapper with Amy voice model
-
-      pandoc
-      wineWowPackages.stable
-      winetricks
-
-      tmate
-      cachix
-
-      anki
-      cloc
-      lshw # list hardware
-      pkgs.xorg.xev # monitor x events
-
-      direnv # https://direnv.net/
-      nix-direnv
-
-      # deal with slow notifications
-      dunst
-      libnotify
-    ];
-    shellAliases = {
-      nix = "nom";
-      nix-shell = "nom-shell";
-      niixos-rebuild = "nixos-rebuild";
-      nixos-rebuild = "nixos-rebuild --no-reexec";
-      nix-build = "nom-build";
-      niix = "${pkgs.nix}/bin/nix -v --fallback";
-      niix-shell = "${pkgs.nix}/bin/nix-shell -v --fallback";
-      niix-build = "${pkgs.nix}/bin/nix-build -v --fallback";
-      vim = "nvim";
-      cp = "cp --reflink=auto"; # btrfs shine
-      ssh = "ssh -C"; # why is this not default?
-      bc = "bc -l"; # fix scale
-    };
-    variables = {
-      LESS = "-F -X -R";
-    };
-    pathsToLink = [
-      "/share/nix-direnv"
-    ];
-
-    # set theme, make font also bigger by default as we've
-    # high res screen
-    etc."xdg/gtk-2.0/gtkrc".text = ''
-      [Settings]
-      gtk-theme-name="Adwaita"
-      gtk-font-name = Noto Sans 18
-    '';
-
-    etc."xdg/gtk-3.0/settings.ini".text = ''
-      [Settings]
-      gtk-theme-name=Adwaita
-      gtk-font-name = Noto Sans 18
-    '';
-
-    variables.QT_QPA_PLATFORMTHEME = "qt5ct";
-
-    # make dunst less ug ug
-    etc."dunst/dunstrc".text = ''
-      [global]
-          ### Serif Style ###
-          # 'Georgia' is high-legibility. If you want a more
-          # classic look, you can use 'Times New Roman'.
-          font = Georgia 18
-
-          format = "<b>%s</b>\n%b"
-          width = 600
-          height = 300
-          offset = 30x50
-          origin = top-right
-          padding = 16
-          horizontal_padding = 16
-          frame_width = 3
-          frame_color = "#F92672" # Molokai Pink
-          separator_color = frame
-
-          # Progress bar
-          progress_bar = true
-          progress_bar_height = 10
-          progress_bar_frame_width = 1
-
-      [urgency_low]
-          background = "#1B1D1E"
-          foreground = "#F8F8F2"
-          frame_color = "#A6E22E" # Molokai Green
-          timeout = 10
-
-      [urgency_normal]
-          background = "#1B1D1E"
-          foreground = "#F8F8F2"
-          frame_color = "#F92672" # Molokai Pink
-          timeout = 15
-
-      [urgency_critical]
-          background = "#1B1D1E"
-          foreground = "#F8F8F2"
-          frame_color = "#FD971F" # Molokai Orange
-          timeout = 0
-    '';
-
-  };
-
-  # fix gnome termianl fonts
-  services.xserver.displayManager.sessionCommands = ''
-    ${pkgs.glib}/bin/gsettings set org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/ use-system-font false
-    ${pkgs.glib}/bin/gsettings set org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/ font 'Fira Code 18'
-  '';
-
-  fonts = {
-    enableDefaultPackages = true;
-    packages = with pkgs; [
-      fira-code
-      fira-code-symbols
-      inconsolata
-      ubuntu-classic
-      corefonts
-      font-awesome_4
-      font-awesome_5
-      siji
-      jetbrains-mono
-      noto-fonts-cjk-sans
-      ipaexfont
-      helvetica-neue-lt-std
-    ];
-    fontconfig = {
-      defaultFonts = {
-        # we need to set in in qt5ct as well.
-        sansSerif = [ "Noto Sans" ];
-        monospace = [ "Fira Code" ];
-      };
-    };
-  };
-
-  services.dbus.packages = [ pkgs.dconf ]; # Ensure dconf has dbus access
-  programs = {
-    # Force GNOME Terminal to use Fira Code 12
-    dconf.enable = true;
-
-    xfconf.enable = true; # allow configuring thunar
-    # can find them here
-    # https://github.com/NixOS/nixpkgs/tree/master/pkgs/desktops/xfce/thunar-plugins
-    # some aren't packaged yet:
-    # https://docs.xfce.org/xfce/thunar/start#thunar_plugins
-    # I think samba would be rad.
-    thunar.plugins = with pkgs.xfce; [
-      thunar-archive-plugin
-      thunar-volman
-      thunar-vcs-plugin
-      thunar-media-tags-plugin
-    ];
-
-    gnupg.agent = {
-      enable = true;
-      enableSSHSupport = true;
-    };
-    vim.defaultEditor = true;
-    vim.enable = true;
-    adb.enable = true;
-    light.enable = true;
-    foot = {
-      enable = true;
-      theme = "molokai"; # Or any base16 theme
-      settings = {
-        scrollback = {
-          lines = 100000;
-        };
-        key-bindings = {
-          "clipboard-paste" = "Control+v";
-        };
-      };
-    };
-
-    waybar = {
-      enable = true;
-      systemd.target = "sway-session.target";
-    };
-  };
+  imports = [ ./base-env.nix ];
+
+  environment.systemPackages = with pkgs; [
+    qbittorrent # bittorent
+
+    kdePackages.kdenlive
+    kdePackages.konsole
+    kdePackages.ark
+    kdePackages.plasma-systemmonitor # monitor my system.. with graphs! (so I don't need to learn real skills)
+
+    (tabletSafe tor-browser)
+    chromium # NB: may also need to be wrapped by tablet safe
+    browsh # better browser, replaces elinks. # NB: leana agrees :):)
+
+    # Heavy GUI apps
+    blender
+    krita
+    gimp # edit my screenshots
+    libreoffice
+    steam
+
+    # Games
+    openrct2
+    starsector
+    openttd
+    openra
+    crawlTiles
+    augustus
+    # eg final fantasy 7 is in ~/ff7
+    # press f4 to laod state
+    # f2 to save
+    (retroarch.withCores (libretro: [
+      # genesis-plus-gx
+      # snes9x
+      libretro.beetle-psx-hw
+    ]))
+
+    zoom-us
+    burpsuite
+    wineWowPackages.stable
+    winetricks
+    chatterino2 # TODO this doesn't work, missing xcb
+  ];
 
   nixpkgs.config = {
     /*
@@ -615,54 +87,7 @@ output eDP-1 resolution 2880x1800 position 0,720
     permittedInsecurePackages = [
       "dotnet-sdk-6.0.428"
       "dotnet-runtime-6.0.36"
-
     ];
-    allowUnfree = true; # I'm horrible, nvidia sucks, TODO kill nvidia
-    packageeverrides = pkgs: {
-      neovim = pkgs.neovim.override {
-        configure = {
-          customRC = ''
-            set syntax=on
-            set autoindent
-            set autowrite
-            set smartcase
-            set showmode
-            set nowrap
-            set number
-            set nocompatible
-            set tw=80
-            set smarttab
-            set smartindent
-            set incsearch
-            set mouse=a
-            set history=10000
-            set completeopt=menuone,menu,longest
-            set wildignore+=*\\tmp\\*,*.swp,*.swo,*.git
-            set wildmode=longest,list,full
-            set wildmenu
-            set t_Co=512
-            set cmdheight=1
-            set expandtab
-            set clipboard=unnamedplus
-            autocmd FileType haskell setlocal sw=4 sts=4 et
-          '';
-          packages.neovim2 = with pkgs.vimPlugins; {
-
-            start = [
-              tabular
-              syntastic
-              vim-nix
-              neomake
-              ctrlp
-              neoformat
-              gitgutter
-            ];
-            opt = [ ];
-          };
-        };
-      };
-
-    };
   };
 
 }

--- a/nix/services.nix
+++ b/nix/services.nix
@@ -2,29 +2,13 @@
 # these are background running programs whihc usually require a
 # lot more configuration than programs invoked by a user, so
 # that's why it's split (I guess)
+#
+# Base services (dunst, sway, pipewire, etc.) are in base-services.nix.
+# This file adds persistent/machine-specific services on top.
 
 { pkgs, ... }:
 {
-  # stops ff and thnderbird from freezing on notifications with i3
-  systemd.user.services.dunst = {
-    description = "Dunst notification daemon";
-    after = [ "graphical-session-pre.target" ];
-
-    partOf = [ "sway-session.target" ];  # Stops dunst if sway-session stops
-    wantedBy = [ "sway-session.target" ]; # Starts dunst when sway-session starts
-
-    unitConfig = {
-      ConditionEnvironment = "WAYLAND_DISPLAY";
-    };
-    serviceConfig = {
-      Type = "dbus";
-      BusName = "org.freedesktop.Notifications";
-      ExecStart = "${pkgs.dunst}/bin/dunst -config /etc/dunst/dunstrc";
-      Restart = "always";
-      RestartSec = 2;
-       };
-  };
-  programs.sway.enable = true;
+  imports = [ ./base-services.nix ];
 
   services = {
 
@@ -72,19 +56,6 @@
       dataDir = "/home/jappie/.config/syncthing-private";
     };
 
-    pipewire = {
-      enable = true;
-      alsa.enable = true;
-      alsa.support32Bit = true;
-      pulse.enable = true;
-    };
-
-    journald.extraConfig = ''
-      SystemMaxUse=50M
-      RuntimeMaxUse=50M
-    '';
-    gvfs.enable = true; # Mount, trash, and other functionalities
-    tumbler.enable = true; # Thumbnail support for images
     tor.enable = true;
     tor.client.enable = true;
 
@@ -122,14 +93,6 @@
         CREATE DATABASE jappie;
         ALTER USER jappie WITH SUPERUSER;
       '';
-    };
-
-    libinput = {
-      enable = true;
-      touchpad = {
-        tapping = true;
-        disableWhileTyping = true;
-      };
     };
 
     displayManager = {
@@ -170,54 +133,13 @@ config = ''
   EndSection
 '';
 
-      xkb = {
-        layout = "us";
-        options = "caps:swapescape";
-      };
-
-      autorun = true; # disable on troubles
       # videoDrivers = [ "amdgpu" "radeon" "cirrus" "vesa" "modesetting" "intel" ];
       videoDrivers = [
         "amdgpu"
         # "modesetting" # generic driver that may intervfere with the "real" one, so disabled for now
       ];
-      windowManager.i3.enable = true;
-      windowManager.i3.extraPackages = [ pkgs.adwaita-qt ];
-      windowManager.i3.extraSessionCommands = ''
-        sleep 1;
-        ${pkgs.xorg.xmodmap}/bin/xmodmap ~/.Xmodmap
-      '';
 
-
-      enable = true;
-    };
-
-    redshift = {
-      enable = true;
-    };
-
-    # https://github.com/rfjakob/earlyoom
-    earlyoom.enable = true; # kills big processes better then kernel
-
-    # the new compoton
-    # https://forum.mxlinux.org/viewtopic.php?p=549425
-    picom = {
-      enable = true;
-      vSync = true;
-      backend = "glx"; # Or "xr_glx_hybrid" if glx freezes
-      inactiveOpacity = 0.925;
-      fadeSteps = [
-        0.04
-        0.04
-      ];
-      settings = {
-        # Crucial for preventing the "freeze" on AMD mobile
-        use-damage = false;
-        xrender-sync-fence = true;
-      };
     };
 
   };
-
-  location.provider = "geoclue2";
 }


### PR DESCRIPTION
## Summary
- Factor out shared services and environment into reusable base modules (`nix/base-services.nix`, `nix/base-env.nix`) so both real machines and the live ISO share the core sway/CLI/dev-tool setup without KDE/Plasma bloat
- Add `iso.nix` — a minimal sway live ISO using `installation-cd-minimal.nix` with emacs, CLI tools, foot, waybar
- Add `iso` and `isoImage` build targets to `default.nix`

## Changes
| File | Action |
|------|--------|
| `nix/base-services.nix` | **NEW** — dunst, sway, pipewire, libinput, earlyoom, redshift, picom, i3, xkb |
| `nix/base-env.nix` | **NEW** — CLI tools, dev tools, haskell/nix tools, fonts, theming, foot, waybar, scripts |
| `nix/services.nix` | **MODIFIED** — imports base-services, keeps openssh, syncthing, postgresql, tor, sddm, plasma6 |
| `nix/environment.nix` | **MODIFIED** — imports base-env, keeps KDE, heavy GUI apps, games, wine |
| `iso.nix` | **NEW** — minimal sway live ISO config |
| `default.nix` | **MODIFIED** — adds iso/isoImage targets |

## Build & Test
```bash
nix-build default.nix -A isoImage
qemu-system-x86_64 -m 4G -cdrom result/iso/jappie-os-live.iso -enable-kvm
```

## Test plan
- [x] `nix-instantiate` succeeds for all existing machine configs (lenovo-tablet, work-machine, lenovo-amd-2022)
- [x] `nix-instantiate` succeeds for new isoImage target
- [ ] Boot ISO in qemu — sway launches, emacs works, CLI tools available

🤖 Generated with [Claude Code](https://claude.com/claude-code)