### PR TITLE
Add i686-linux to nix extra-platforms

### DIFF
--- a/nix/config.nix
+++ b/nix/config.nix
@@ -41,6 +41,11 @@ in
     '';
     settings = {
 
+      # x86_64 Linux can natively execute i686 binaries — no QEMU needed.
+      # Tells the nix daemon it may build i686-linux derivations (required by
+      # some Android SDK tools like ncurses-abi5-compat).
+      extra-platforms = [ "i686-linux" ];
+
       # starts the gc when there is less then 50GB in storage
       min-free = 20 * 1024 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary
- Adds `extra-platforms = [ "i686-linux" ]` to `nix.settings` in `nix/config.nix`
- Fixes Android SDK builds from Claude containers that need 32-bit derivations (e.g. `ncurses-abi5-compat`)
- No QEMU/binfmt needed — x86_64 Linux runs i686 binaries natively, this just tells the nix daemon it's allowed

## Context
When building `haskell-mobile` Android cross-compilation inside a Claude container, the remote nix builder refused to build `ncurses-abi5-compat` (an i686-linux derivation needed by Android SDK tooling). The container tried to work around this locally, which OOM-killed the process.

## Test plan
- [ ] `nixos-rebuild switch` on lenovo-tablet
- [ ] Verify `nix show-config | grep extra-platforms` includes `i686-linux`
- [ ] Build a haskell-mobile Android derivation from a Claude container

🤖 Generated with [Claude Code](https://claude.com/claude-code)