### PR TITLE
Add URL click support to foot terminal

### DIFF
--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -591,6 +591,10 @@ output eDP-1 resolution 2880x1800 position 0,720
         key-bindings = {
           "clipboard-paste" = "Control+v";
         };
+        url = {
+          launch = "xdg-open \${url}";
+          protocols = "http, https, ftp, ftps, file, gemini";
+        };
       };
     };
 


### PR DESCRIPTION
## Summary
- Configures foot to detect and open URLs via `xdg-open`
- `ctrl+shift+u` enters URL mode, `ctrl+click` opens links directly

## Test plan
- [ ] Run `nixos-rebuild switch` and verify foot picks up the new config
- [ ] Check that URLs in terminal output are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)