### PR TITLE
Remove invalid protocols option from foot url config

### DIFF
--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -593,7 +593,6 @@ output eDP-1 resolution 2880x1800 position 0,720
         };
         url = {
           launch = "xdg-open \${url}";
-          protocols = "http, https, ftp, ftps, file, gemini";
         };
       };
     };


### PR DESCRIPTION
## Summary
- Remove `protocols` from `[url]` section in foot settings — it's not a valid foot.ini option
- Fixes startup error: `foot: /etc/xdg/foot/foot.ini:12: [url].protocols: not a valid option: protocols`
- The valid `[url]` options are: `launch`, `label-letters`, `osc8-underline`, and `regex`

## Test plan
- [ ] `nixos-rebuild switch` and confirm foot launches without the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)