### PR TITLE
Enable KVM for QEMU hardware acceleration

### DIFF
--- a/work-machine.nix
+++ b/work-machine.nix
@@ -12,25 +12,12 @@
 
   # Use the systemd-boot EFI boot loader.
   boot = {
-    /*
-   solves:
-
-    VirtualBox can't enable the AMD-V extension. Please disable the KVM kernel extension, recompile your kernel and reboot (VERR_SVM_IN_USE).
-    Result Code:
-    NS_ERROR_FAILURE (0x80004005)
-    Component:
-    ConsoleWrap
-    Interface:
-    IConsole {6ac83d89-6ee7-4e33-8ae6-b257b2e81be8}
-    */
-    blacklistedKernelModules = [ "kvm_amd" "kvm" ];
     loader.systemd-boot.enable = true;
     loader.efi.canTouchEfiVariables = true;
     plymouth = {
       enable = false;
       theme = "spinfinity"; # spinfinity
     };
-    kernelParams = [ "kvm.enable_virt_at_load=0" ];
     # kernelPackages = pkgs.linuxKernel.packages.linux_6_1; #  6.6 don't boot?
   };
 
@@ -240,6 +227,7 @@
       "docker"
       "vboxusers"
       "podman"
+      "kvm"
     ];
     # openssh.authorizedKeys.keys = (import ./encrypted/keys.nix); # TODO renable
     group = "users";


### PR DESCRIPTION
## Summary

- Remove `kvm_amd`/`kvm` kernel module blacklist (VirtualBox is already disabled, so the conflict no longer applies)
- Remove `kvm.enable_virt_at_load=0` kernel param
- Add `kvm` group to jappie for `/dev/kvm` access

After `nixos-rebuild switch` and reboot, QEMU will use hardware acceleration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)