### PR TITLE
hostdir: forward "$@" to python http.server

### DIFF
--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -33,7 +33,7 @@ let
   unstable3 = import sources.unstable3 { };
 
   hostdir = pkgs.writeShellScriptBin "hostdir" ''
-    ${pkgs.lib.getExe pkgs.python3} -m http.server
+    ${pkgs.lib.getExe pkgs.python3} -m http.server "$@"
   '';
 
   # phone makes pictures to big usually


### PR DESCRIPTION
## Summary

- Without arg passthrough, `hostdir 8000` (or `--bind`, `--directory`, …)
  is silently ignored and the server always falls back to the default
  port.
- One-line fix: add `"$@"` after `-m http.server` so callers can pass
  anything `python -m http.server` understands.

## Test plan

- [x] `nix-shell -p (writeShellScriptBin "hostdir" ''...'')` → `hostdir 8767`
      actually listens on 8767

🤖 Generated with [Claude Code](https://claude.com/claude-code)