### PR TITLE
Allow passwordless sudo for systemd-nspawn

### DIFF
--- a/lenovo-amd-2022.nix
+++ b/lenovo-amd-2022.nix
@@ -55,6 +55,9 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
   security.sudo.extraRules = [
     { groups = [ "sudo" ]; commands = [{ command = "${pkgs.systemd}/bin/poweroff"; options = [ "NOPASSWD" ]; }]; }
+    # claude-env's claude.sh launcher shells out to systemd-nspawn, which has
+    # no rootless mode. Allowlist it so the launcher doesn't prompt.
+    { groups = [ "sudo" ]; commands = [{ command = "${pkgs.systemd}/bin/systemd-nspawn"; options = [ "NOPASSWD" ]; }]; }
   ];
   security.sudo.extraConfig = ''
     Defaults        timestamp_timeout=120

--- a/lenovo-tablet.nix
+++ b/lenovo-tablet.nix
@@ -73,6 +73,9 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
   security.sudo.extraRules = [
     { groups = [ "sudo" ]; commands = [{ command = "${pkgs.systemd}/bin/poweroff"; options = [ "NOPASSWD" ]; }]; }
+    # claude-env's claude.sh launcher shells out to systemd-nspawn, which has
+    # no rootless mode. Allowlist it so the launcher doesn't prompt.
+    { groups = [ "sudo" ]; commands = [{ command = "${pkgs.systemd}/bin/systemd-nspawn"; options = [ "NOPASSWD" ]; }]; }
   ];
   security.sudo.extraConfig = ''
     Defaults        timestamp_timeout=120

--- a/work-machine.nix
+++ b/work-machine.nix
@@ -23,6 +23,9 @@
 
   security.sudo.extraRules = [
     { groups = [ "sudo" ]; commands = [{ command = "${pkgs.systemd}/bin/poweroff"; options = [ "NOPASSWD" ]; }]; }
+    # claude-env's claude.sh launcher shells out to systemd-nspawn, which has
+    # no rootless mode. Allowlist it so the launcher doesn't prompt.
+    { groups = [ "sudo" ]; commands = [{ command = "${pkgs.systemd}/bin/systemd-nspawn"; options = [ "NOPASSWD" ]; }]; }
   ];
   security.sudo.extraConfig = ''
     Defaults        timestamp_timeout=120


### PR DESCRIPTION
## Summary
- `claude-env`'s `claude.sh` launcher shells out to `systemd-nspawn` on every run, and nspawn has no rootless mode.
- Adds a `NOPASSWD` sudoers entry for `${pkgs.systemd}/bin/systemd-nspawn` (sudo group) on each host config, so the launcher no longer prompts for a password.
- Mirrors the existing `poweroff` allowlist pattern; applied identically to `work-machine.nix`, `lenovo-amd-2022.nix`, and `lenovo-tablet.nix`.

## Test plan
- [ ] `nixos-rebuild switch` on a target host
- [ ] Run `./claude.sh <instance>` from claude-env and confirm no password prompt
- [ ] Confirm other sudo invocations still prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)