### PR TITLE
Declarative email: Send Later addon + hotmail account via home-manager

### DIFF
--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -26,6 +26,23 @@ let
       '';
     };
 
+  # Decision: the Send Later addon (scheduled email sending) is installed
+  # through Thunderbird's enterprise policy ExtensionSettings, force_installed
+  # from addons.thunderbird.net. Alternatives considered: home-manager's
+  # programs.thunderbird (this repo doesn't use home-manager) and installing
+  # the addon by hand in the profile (not declarative, lost on profile wipe).
+  # force_installed keeps it declarative while ATN still provides updates.
+  thunderbirdWithSendLater = pkgs.thunderbird.override {
+    extraPolicies = {
+      ExtensionSettings = {
+        "sendlater3@kamens.us" = {
+          installation_mode = "force_installed";
+          install_url = "https://addons.thunderbird.net/thunderbird/downloads/latest/send-later-3/latest.xpi";
+        };
+      };
+    };
+  };
+
   agenix = fuckingFlake sources.agenix.outPath;
 
   unstable = import sources.unstable { };
@@ -474,7 +491,7 @@ output eDP-1 resolution 2880x1800 position 0,720
       pavucontrol
       gparted # partitiioning for dummies, like me
 
-      (tabletSafe thunderbird) # some day I'll use emacs for this
+      (tabletSafe thunderbirdWithSendLater) # some day I'll use emacs for this
       # the spell to make openvpn work:   nmcli connection modify jappie vpn.data "key = /home/jappie/openvpn/website/jappie.key, ca = /home/jappie/openvpn/website/ca.crt, dev = tun, cert = /home/jappie/openvpn/website/jappie.crt, ns-cert-type = server, cert-pass-flags = 0, comp-lzo = adaptive, remote = jappieklooster.nl:1194, connection-type = tls"
       # from https://github.com/NixOS/nixpkgs/issues/30235
       openvpn # piratebay access


### PR DESCRIPTION
Three commits that make email fully declarative.

## Commit 1: Send Later addon
The `thunderbird` package is overridden with `extraPolicies.ExtensionSettings`, force-installing [Send Later](https://addons.thunderbird.net/en-US/thunderbird/addon/send-later-3/) (`sendlater3@kamens.us`) from addons.thunderbird.net, enabling scheduled email sending.

## Commits 2 and 3: accounts via home-manager (narrow adoption)
Only email lives in home-manager; dotfiles keep the symlink scheme.

- home-manager pinned in npins (release-25.11, matching the nixpkgs pin), imported as a NixOS module in new `nix/email.nix` so plain `nixos-rebuild switch` applies it
- three accounts. Two hosted on Zoho's EU datacenter (both domains' MX point at mx.zoho.eu): `hi@jappie.me` (personal, primary) and `hallo@jappiesoftware.com` (business), plus jacobtjeerd@hotmail.com (Microsoft, outlook.office365.com flavor with OAuth2 forced since Microsoft rejects password auth). Explicit zoho servers since home-manager has no zoho flavor: `imappro.zoho.eu:993` SSL, `smtppro.zoho.eu:465` SSL, password auth (Thunderbird has no built-in Zoho OAuth2). Passwords stay non-declarative: Thunderbird prompts once per account; with 2FA on Zoho that's an app-specific password from accounts.zoho.eu
- thunderbird (with the Send Later policy) moved from `environment.systemPackages` to `programs.thunderbird.package` under home-manager, so there's exactly one thunderbird
- `tabletSafe` extracted to `nix/tablet-safe.nix`, shared by environment.nix and email.nix

## Migration note (first switch on a machine with an existing profile)
home-manager writes `~/.thunderbird/profiles.ini` listing only the declared `jappie` profile; an existing hand-written one is backed up as `profiles.ini.hm-backup` (via `backupFileExtension`). Your old profile directory stays on disk but won't be listed; since mail is IMAP it re-syncs into the new profile, or you can copy the old profile's contents into `~/.thunderbird/jappie` before first launch.

## Verification
- All three systems (`lenevo-amd-2022`, `work-machine`, `lenovo-tablet`) instantiate against the pins.
- Built the generated `user.js`: both identities present, `imappro.zoho.eu:993` and `smtppro.zoho.eu:465` with SSL (socketType/try_ssl 3) and password auth on both accounts.
- Built the tabletSafe-wrapped thunderbird: wayland env vars set, `distribution/policies.json` carries the Send Later force-install block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)