### PR TITLE
Preconfigure email accounts via narrow home-manager adoption

### DIFF
--- a/lenovo-amd-2022.nix
+++ b/lenovo-amd-2022.nix
@@ -25,6 +25,7 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
     ./emacs
     ./nix/config.nix
     ./nix/environment.nix
+    ./nix/email.nix
     ./nix/services.nix
   ];
 

--- a/lenovo-tablet.nix
+++ b/lenovo-tablet.nix
@@ -35,6 +35,7 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
     ./emacs
     ./nix/config.nix
     ./nix/environment.nix
+    ./nix/email.nix
     ./nix/services.nix
   ];
 

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -21,18 +21,21 @@ let
   # installing the addon by hand in the profile (not declarative, lost on
   # profile wipe). force_installed keeps it declarative while ATN still
   # provides updates.
-  # an email account on zoho's EU datacenter, preconfigured for thunderbird
+  # an email account on zoho's EU datacenter, preconfigured for thunderbird.
+  # the "pro" hosts are zoho's servers for domain-based addresses; the
+  # plain imap.zoho.eu/smtp.zoho.eu ones are only for @zoho.com addresses
+  # (https://www.zoho.com/mail/help/imap-access.html)
   zohoEuAccount = address: {
     inherit address;
     userName = address;
     realName = "Jappie Klooster";
     imap = {
-      host = "imap.zoho.eu";
+      host = "imappro.zoho.eu";
       port = 993;
       tls.enable = true;
     };
     smtp = {
-      host = "smtp.zoho.eu";
+      host = "smtppro.zoho.eu";
       port = 465;
       tls.enable = true;
     };

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -21,6 +21,24 @@ let
   # installing the addon by hand in the profile (not declarative, lost on
   # profile wipe). force_installed keeps it declarative while ATN still
   # provides updates.
+  # an email account on zoho's EU datacenter, preconfigured for thunderbird
+  zohoEuAccount = address: {
+    inherit address;
+    userName = address;
+    realName = "Jappie Klooster";
+    imap = {
+      host = "imap.zoho.eu";
+      port = 993;
+      tls.enable = true;
+    };
+    smtp = {
+      host = "smtp.zoho.eu";
+      port = 465;
+      tls.enable = true;
+    };
+    thunderbird.enable = true;
+  };
+
   thunderbirdWithSendLater = pkgs.thunderbird.override {
     extraPolicies = {
       ExtensionSettings = {
@@ -50,27 +68,18 @@ in
     # not something to bump on upgrades
     home.stateVersion = "25.11";
 
-    accounts.email.accounts.hotmail = {
-      primary = true;
-      address = "jappieklooster@hotmail.com";
-      realName = "Jappie Klooster";
-      # fills in outlook.office365.com imap and smtp.office365.com smtp
-      flavor = "outlook.office365.com";
-      thunderbird = {
-        enable = true;
-        # settings is a function: home-manager calls it with the account's
-        # generated id so the prefs below land on the right numbered
-        # server entries in the thunderbird profile.
-        # Microsoft only accepts OAuth2 for personal accounts, but the
-        # home-manager module defaults to password auth (3) for every
-        # flavor except gmail. 10 = OAuth2. The password itself is not
-        # declarative: thunderbird runs the microsoft login flow on first
-        # connect and stores the token in its own credential store.
-        settings = id: {
-          "mail.server.server_${id}.authMethod" = 10;
-          "mail.smtpserver.smtp_${id}.authMethod" = 10;
-        };
+    # Both mailboxes are hosted on zoho. The MX records of both domains
+    # point at mx.zoho.eu, so the EU datacenter servers apply, not the
+    # zoho.com ones. home-manager has no zoho flavor, hence explicit
+    # servers (zohoEuAccount below). Passwords are not declarative:
+    # thunderbird prompts on first connect and stores them itself. With
+    # two factor auth enabled on zoho, that password has to be an
+    # app-specific one, generated at https://accounts.zoho.eu.
+    accounts.email.accounts = {
+      personal = zohoEuAccount "hi@jappie.me" // {
+        primary = true;
       };
+      business = zohoEuAccount "hallo@jappiesoftware.com";
     };
 
     programs.thunderbird = {

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -83,6 +83,27 @@ in
         primary = true;
       };
       business = zohoEuAccount "hallo@jappiesoftware.com";
+
+      hotmail = {
+        address = "jacobtjeerd@hotmail.com";
+        realName = "Jappie Klooster";
+        # fills in outlook.office365.com imap and smtp.office365.com smtp
+        flavor = "outlook.office365.com";
+        thunderbird = {
+          enable = true;
+          # settings is a function: home-manager calls it with the
+          # account's generated id so the prefs land on the right
+          # numbered server entries in the thunderbird profile.
+          # Microsoft only accepts OAuth2 for personal accounts, but
+          # home-manager defaults to password auth (3) for every flavor
+          # except gmail. 10 = OAuth2. The login flow runs interactively
+          # once on first connect, thunderbird keeps the token.
+          settings = id: {
+            "mail.server.server_${id}.authMethod" = 10;
+            "mail.smtpserver.smtp_${id}.authMethod" = 10;
+          };
+        };
+      };
     };
 
     programs.thunderbird = {

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -1,0 +1,84 @@
+# Email configuration.
+#
+# Decision: email is managed through home-manager, imported here as a NixOS
+# module so `nixos-rebuild switch` applies it (no separate home-manager
+# command). Plain NixOS was considered: its programs.thunderbird module only
+# exposes policies and preferences, it cannot declare accounts. home-manager's
+# thunderbird module generates the account prefs (mail.server.*,
+# mail.smtpserver.*, mail.identity.*) from a single accounts.email entry.
+# Adoption is deliberately narrow: only email lives in home-manager, all other
+# dotfiles keep using the symlink scheme from scripts/install-nixos.sh, which
+# allows live editing without a rebuild.
+{ pkgs, ... }:
+let
+  sources = import ../npins;
+  tabletSafe = import ./tablet-safe.nix pkgs;
+
+  # Decision: the Send Later addon (scheduled email sending) is installed
+  # through Thunderbird's enterprise policy ExtensionSettings, force_installed
+  # from addons.thunderbird.net. Alternatives considered: home-manager's
+  # extensions option (needs a manually pinned xpi hash that goes stale) and
+  # installing the addon by hand in the profile (not declarative, lost on
+  # profile wipe). force_installed keeps it declarative while ATN still
+  # provides updates.
+  thunderbirdWithSendLater = pkgs.thunderbird.override {
+    extraPolicies = {
+      ExtensionSettings = {
+        "sendlater3@kamens.us" = {
+          installation_mode = "force_installed";
+          install_url = "https://addons.thunderbird.net/thunderbird/downloads/latest/send-later-3/latest.xpi";
+        };
+      };
+    };
+  };
+in
+{
+  imports = [ (sources.home-manager + "/nixos") ];
+
+  # reuse the system nixpkgs (with overlays) instead of a private import,
+  # and install user packages via the system profile
+  home-manager.useGlobalPkgs = true;
+  home-manager.useUserPackages = true;
+
+  # if a file home-manager wants to manage already exists (e.g. a
+  # profiles.ini written by a previously hand-configured thunderbird),
+  # move it aside instead of failing the activation
+  home-manager.backupFileExtension = "hm-backup";
+
+  home-manager.users.jappie = {
+    # version of home-manager option defaults at first adoption,
+    # not something to bump on upgrades
+    home.stateVersion = "25.11";
+
+    accounts.email.accounts.hotmail = {
+      primary = true;
+      address = "jappieklooster@hotmail.com";
+      realName = "Jappie Klooster";
+      # fills in outlook.office365.com imap and smtp.office365.com smtp
+      flavor = "outlook.office365.com";
+      thunderbird = {
+        enable = true;
+        # settings is a function: home-manager calls it with the account's
+        # generated id so the prefs below land on the right numbered
+        # server entries in the thunderbird profile.
+        # Microsoft only accepts OAuth2 for personal accounts, but the
+        # home-manager module defaults to password auth (3) for every
+        # flavor except gmail. 10 = OAuth2. The password itself is not
+        # declarative: thunderbird runs the microsoft login flow on first
+        # connect and stores the token in its own credential store.
+        settings = id: {
+          "mail.server.server_${id}.authMethod" = 10;
+          "mail.smtpserver.smtp_${id}.authMethod" = 10;
+        };
+      };
+    };
+
+    programs.thunderbird = {
+      enable = true;
+      package = tabletSafe thunderbirdWithSendLater;
+      profiles.jappie = {
+        isDefault = true;
+      };
+    };
+  };
+}

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -6,6 +6,11 @@
 # exposes policies and preferences, it cannot declare accounts. home-manager's
 # thunderbird module generates the account prefs (mail.server.*,
 # mail.smtpserver.*, mail.identity.*) from a single accounts.email entry.
+# The motivating problem: machines got set up with different subsets of
+# accounts because adding them was manual and rare (about once a year),
+# so some address was always forgotten somewhere. Declaring them here
+# makes every machine converge on the same account list; only the
+# authentication of each account remains a manual, per machine step.
 # Adoption is deliberately narrow: only email lives in home-manager, all other
 # dotfiles keep using the symlink scheme from scripts/install-nixos.sh, which
 # allows live editing without a rebuild.

--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -10,38 +10,7 @@ let
   # unfuck the flake, unsubscribe from the mental health workshop.
   fuckingFlake = outPath: (import sources.flake-compat { src = outPath; }).outputs;
 
-  # Forces wayland,
-  # also enables touch support
-  tabletSafe =
-    pkg:
-    pkgs.symlinkJoin {
-      name = "${pkg.pname or "app"}-tablet-safe";
-      paths = [ pkg ];
-      buildInputs = [ pkgs.makeWrapper ];
-      postBuild = ''
-        # We find the main binary and wrap it with our safety flags
-        wrapProgram $out/bin/${pkg.pname or (builtins.parseDrvName pkg.name).name} \
-          --set MOZ_USE_XINPUT2 "1" \
-          --set MOZ_ENABLE_WAYLAND "1"
-      '';
-    };
-
-  # Decision: the Send Later addon (scheduled email sending) is installed
-  # through Thunderbird's enterprise policy ExtensionSettings, force_installed
-  # from addons.thunderbird.net. Alternatives considered: home-manager's
-  # programs.thunderbird (this repo doesn't use home-manager) and installing
-  # the addon by hand in the profile (not declarative, lost on profile wipe).
-  # force_installed keeps it declarative while ATN still provides updates.
-  thunderbirdWithSendLater = pkgs.thunderbird.override {
-    extraPolicies = {
-      ExtensionSettings = {
-        "sendlater3@kamens.us" = {
-          installation_mode = "force_installed";
-          install_url = "https://addons.thunderbird.net/thunderbird/downloads/latest/send-later-3/latest.xpi";
-        };
-      };
-    };
-  };
+  tabletSafe = import ./tablet-safe.nix pkgs;
 
   agenix = fuckingFlake sources.agenix.outPath;
 
@@ -491,7 +460,7 @@ output eDP-1 resolution 2880x1800 position 0,720
       pavucontrol
       gparted # partitiioning for dummies, like me
 
-      (tabletSafe thunderbirdWithSendLater) # some day I'll use emacs for this
+      # thunderbird moved to email.nix, it's managed by home-manager now
       # the spell to make openvpn work:   nmcli connection modify jappie vpn.data "key = /home/jappie/openvpn/website/jappie.key, ca = /home/jappie/openvpn/website/ca.crt, dev = tun, cert = /home/jappie/openvpn/website/jappie.crt, ns-cert-type = server, cert-pass-flags = 0, comp-lzo = adaptive, remote = jappieklooster.nl:1194, connection-type = tls"
       # from https://github.com/NixOS/nixpkgs/issues/30235
       openvpn # piratebay access

--- a/nix/tablet-safe.nix
+++ b/nix/tablet-safe.nix
@@ -1,0 +1,15 @@
+# Forces wayland, also enables touch support.
+# Shared between environment.nix (system packages) and email.nix
+# (the home-manager thunderbird package).
+pkgs: pkg:
+pkgs.symlinkJoin {
+  name = "${pkg.pname or "app"}-tablet-safe";
+  paths = [ pkg ];
+  buildInputs = [ pkgs.makeWrapper ];
+  postBuild = ''
+    # We find the main binary and wrap it with our safety flags
+    wrapProgram $out/bin/${pkg.pname or (builtins.parseDrvName pkg.name).name} \
+      --set MOZ_USE_XINPUT2 "1" \
+      --set MOZ_ENABLE_WAYLAND "1"
+  '';
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -55,6 +55,20 @@
       "url": "https://api.github.com/repos/nixos/flake-compat/tarball/v1.1.0",
       "hash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU="
     },
+    "home-manager": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "nix-community",
+        "repo": "home-manager"
+      },
+      "branch": "release-25.11",
+      "submodules": false,
+      "revision": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+      "url": "https://github.com/nix-community/home-manager/archive/3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f.tar.gz",
+      "hash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+      "frozen": false
+    },
     "leana-dotfiles": {
       "type": "Git",
       "repository": {

--- a/work-machine.nix
+++ b/work-machine.nix
@@ -7,6 +7,7 @@
     ./emacs
     ./nix/config.nix
     ./nix/environment.nix
+    ./nix/email.nix
     ./nix/services.nix
   ];
 


### PR DESCRIPTION
Follow-up to #28 (these commits were pushed to that branch after it merged, so they never entered a PR).

## Summary
Machines kept ending up with different subsets of email accounts because adding them was manual and rare, so one was always forgotten somewhere. This declares the account list once, and every machine converges on it; only authentication remains a per-machine step.

- home-manager pinned in npins (release-25.11, matching the nixpkgs pin) and imported as a NixOS module in new `nix/email.nix`, so plain `nixos-rebuild switch` applies it. Adoption is deliberately narrow: only email lives in home-manager, dotfiles keep the symlink scheme.
- three accounts declared: `hi@jappie.me` (personal, primary) and `hallo@jappiesoftware.com` (business), both on Zoho's EU datacenter (`imappro.zoho.eu:993` / `smtppro.zoho.eu:465`, the "pro" hosts Zoho documents for domain-based addresses), plus `jacobtjeerd@hotmail.com` (outlook flavor, OAuth2 forced since Microsoft rejects password auth).
- thunderbird (with the Send Later policy from #28) moved from `environment.systemPackages` to home-manager's `programs.thunderbird.package`, so there's exactly one thunderbird; `tabletSafe` extracted to `nix/tablet-safe.nix` and shared.
- passwords stay non-declarative: Thunderbird prompts once per account (app-specific password for Zoho if 2FA is on, Microsoft's browser flow for hotmail).

Migration note: home-manager writes `~/.thunderbird/profiles.ini` listing only the declared `jappie` profile; an existing hand-written one is backed up as `profiles.ini.hm-backup`. The old profile directory stays on disk but unlisted; IMAP re-syncs into the new profile, or copy the old profile's contents into `~/.thunderbird/jappie` before first launch.

## Test plan
- [x] all three systems instantiate against the pins (`nix-instantiate default.nix -A <machine>.config.system.build.toplevel`)
- [x] generated `user.js` contains all three identities, zoho pro hosts with SSL, OAuth2 (10) on the hotmail servers
- [x] tabletSafe-wrapped thunderbird builds; `distribution/policies.json` carries the Send Later force-install block
- [ ] `nixos-rebuild switch` on a real machine, open thunderbird, auth each account once

🤖 Generated with [Claude Code](https://claude.com/claude-code)