### PR TITLE
Thunderbird: order accounts and rename hotmail to backup-personal

### DIFF
--- a/nix/email.nix
+++ b/nix/email.nix
@@ -116,6 +116,13 @@ in
       package = tabletSafe thunderbirdWithSendLater;
       profiles.jappie = {
         isDefault = true;
+        # ordering in the folder pane; independent of which account is
+        # primary (that stays personal)
+        accountsOrder = [
+          "business"
+          "personal"
+          "hotmail"
+        ];
       };
     };
   };

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -19,13 +19,6 @@ let
   sources = import ../npins;
   tabletSafe = import ./tablet-safe.nix pkgs;
 
-  # Decision: the Send Later addon (scheduled email sending) is installed
-  # through Thunderbird's enterprise policy ExtensionSettings, force_installed
-  # from addons.thunderbird.net. Alternatives considered: home-manager's
-  # extensions option (needs a manually pinned xpi hash that goes stale) and
-  # installing the addon by hand in the profile (not declarative, lost on
-  # profile wipe). force_installed keeps it declarative while ATN still
-  # provides updates.
   # an email account on zoho's EU datacenter, preconfigured for thunderbird.
   # the "pro" hosts are zoho's servers for domain-based addresses; the
   # plain imap.zoho.eu/smtp.zoho.eu ones are only for @zoho.com addresses
@@ -47,6 +40,13 @@ let
     thunderbird.enable = true;
   };
 
+  # Decision: the Send Later addon (scheduled email sending) is installed
+  # through Thunderbird's enterprise policy ExtensionSettings, force_installed
+  # from addons.thunderbird.net. Alternatives considered: home-manager's
+  # extensions option (needs a manually pinned xpi hash that goes stale) and
+  # installing the addon by hand in the profile (not declarative, lost on
+  # profile wipe). force_installed keeps it declarative while ATN still
+  # provides updates.
   thunderbirdWithSendLater = pkgs.thunderbird.override {
     extraPolicies = {
       ExtensionSettings = {
@@ -89,7 +89,7 @@ in
       };
       business = zohoEuAccount "hallo@jappiesoftware.com";
 
-      hotmail = {
+      backup-personal = {
         address = "jacobtjeerd@hotmail.com";
         realName = "Jappie Klooster";
         # fills in outlook.office365.com imap and smtp.office365.com smtp
@@ -121,7 +121,7 @@ in
         accountsOrder = [
           "business"
           "personal"
-          "hotmail"
+          "backup-personal"
         ];
       };
     };


### PR DESCRIPTION
Follow-up to #29; these two commits were pushed to that branch after it merged, so they never entered a PR.

## Summary
- Folder pane now orders accounts business, personal, backup-personal (then Local Folders), via home-manager's `accountsOrder` profile option, which drives the `mail.accountmanager.accounts` pref. Ordering is independent of the `primary` flag, which stays on personal.
- The hotmail account attribute is renamed to `backup-personal`: the attribute name is what Thunderbird displays and what `accountsOrder` references, so it should describe the role, not the provider. Renaming changes the generated account ids, harmless since nothing deployed the old name yet.
- The Send Later Decision comment moved back next to `thunderbirdWithSendLater`; an earlier edit had stranded it above `zohoEuAccount`.

## Test plan
- [x] generated `user.js` lists accounts in order business, personal, backup-personal, Local Folders (ids resolved back to addresses)
- [x] system still instantiates (the `user.js` build evaluates the full module fixpoint)
- [ ] after `nixos-rebuild switch`: folder pane shows the three accounts in that order

🤖 Generated with [Claude Code](https://claude.com/claude-code)