### PR TITLE
Dirvish: bind h/l for ranger-style directory navigation

### DIFF
--- a/emacs/emacs.el
+++ b/emacs/emacs.el
@@ -273,6 +273,11 @@
    ;; instead of dumping them in a buffer.
    dirvish-preview-disabled-exts '("bin" "exe" "gpg" "elc" "eln" "gz" "mkv" "iso" "mp4")
    )
+  ;; ranger-style navigation. ranger.el shipped its own vim keymap;
+  ;; dirvish inherits dired's, where evil keeps h/l as char motions.
+  (evil-define-key 'normal dirvish-mode-map
+    "h" 'dired-up-directory
+    "l" 'dired-find-file)
   )
 
 ;;; show what keys are possible


### PR DESCRIPTION
Follow-up to #31, which merged while this fix was in flight.

## Summary
`h`/`l` didn't navigate because ranger.el shipped its own vim-style keymap while dirvish inherits dired's, where evil keeps those keys as plain character motions. This binds them in dirvish-mode-map's normal state: `h` goes up a directory, `l` enters a directory or opens the file (matching ranger's behaviour).

## Test plan
- [x] in the built emacs with the full config loaded, both keys resolve to the dired commands in dirvish's normal-state keymap
- [ ] on a real machine: `l` descends into a directory, `h` ascends

🤖 Generated with [Claude Code](https://claude.com/claude-code)