### PR TITLE
Add shared aanleveringen syncthing folder across three machines

### DIFF
--- a/lenovo-amd-2022.nix
+++ b/lenovo-amd-2022.nix
@@ -245,6 +245,18 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
             "lenovo-amd-2022"
           ];
         };
+        # Shared client-deliveries inbox (merchant uploads: Elizabeth/kruidje,
+        # Ellen/waardegebaar). The vibes runner (jappeace/vibes claude.sh)
+        # read-only-mounts this same path into every instance at
+        # ~/aanleveringen, so instances can read what lands here.
+        "/home/jappie/aanleveringen" = {
+          id = "aanleveringen";
+          devices = [
+            "work-machine"
+            "lenovo-amd-2022"
+            "lenovo-tablet"
+          ];
+        };
       };
 
     logind = {

--- a/lenovo-tablet.nix
+++ b/lenovo-tablet.nix
@@ -298,6 +298,18 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
             "lenovo-tablet"
           ];
         };
+        # Shared client-deliveries inbox (merchant uploads: Elizabeth/kruidje,
+        # Ellen/waardegebaar). The vibes runner (jappeace/vibes claude.sh)
+        # read-only-mounts this same path into every instance at
+        # ~/aanleveringen, so instances can read what lands here.
+        "/home/jappie/aanleveringen" = {
+          id = "aanleveringen";
+          devices = [
+            "work-machine"
+            "lenovo-amd-2022"
+            "lenovo-tablet"
+          ];
+        };
     };
 
     logind = {

--- a/work-machine.nix
+++ b/work-machine.nix
@@ -217,6 +217,18 @@
             "lenovo-amd-2022"
           ];
         };
+        # Shared client-deliveries inbox (merchant uploads: Elizabeth/kruidje,
+        # Ellen/waardegebaar). The vibes runner (jappeace/vibes claude.sh)
+        # read-only-mounts this same path into every instance at
+        # ~/aanleveringen, so instances can read what lands here.
+        "/home/jappie/aanleveringen" = {
+          id = "aanleveringen";
+          devices = [
+            "work-machine"
+            "lenovo-amd-2022"
+            "lenovo-tablet"
+          ];
+        };
     };
 
   # Define a user account. Don't forget to set a password with ‘passwd’.


### PR DESCRIPTION
## What

Sync `/home/jappie/aanleveringen` between **work-machine**, **lenovo-amd-2022** and **lenovo-tablet** by adding the folder to each machine's `services.syncthing.settings.folders`. Folder id `aanleveringen`; devices already exist centrally in `nix/services.nix`.

## Why

Shared client-deliveries inbox for merchant uploads (Elizabeth/kruidje, Ellen/waardegebaar). The companion PR in `jappeace/vibes` read-only-mounts this same host path into every instance at `~/aanleveringen`, so instances can read whatever Syncthing lands here. Both repos name the same absolute path on purpose.

## Notes

- `nix-instantiate --parse` passes on all three edited files. Not `nixos-rebuild`-tested in-sandbox (host-specific).
- Folder blocks follow the existing per-machine "describe devices from this device's perspective" style.
- Pairs with jappeace/vibes `feat/shared-aanleveringen-mount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)