### PR TITLE
Thunderbird: newest mail on top, unthreaded

### DIFF
--- a/nix/email.nix
+++ b/nix/email.nix
@@ -123,6 +123,16 @@ in
           "personal"
           "backup-personal"
         ];
+        # Newest mail on top, never threaded. These are the default view a
+        # folder gets the first time it is opened; a folder already opened
+        # keeps the sort cached in its .msf, so a wiped profile (or a fresh
+        # machine, the common case here) is what makes these take effect.
+        # 18 = sort by date, 2 = descending, 0 = unthreaded flat list.
+        settings = {
+          "mailnews.default_sort_type" = 18;
+          "mailnews.default_sort_order" = 2;
+          "mailnews.default_view_flags" = 0;
+        };
       };
     };
   };


### PR DESCRIPTION
## What

Make Thunderbird default to **newest email on top, unthreaded** on every machine, via the existing home-manager email provisioning in `nix/email.nix`.

Adds three view prefs to `programs.thunderbird.profiles.jappie.settings`, which land in the profile's `user.js`:

- `mailnews.default_sort_type = 18` (sort by date)
- `mailnews.default_sort_order = 2` (descending)
- `mailnews.default_view_flags = 0` (flat, unthreaded)

Done on the profile settings (not the symlink dotfile scheme) to stay consistent with how email is already declared here.

## Caveat

These are the default view a folder gets the **first time it is opened**. A folder that was already opened keeps its sort cached in its `.msf`, so this takes full effect on a fresh profile/machine. An existing folder can be reset once with `View > Sort By`, or by deleting its `.msf`.

## Verification

Built the generated `user.js` for the `jappie` profile (via `lenovo-tablet` toplevel eval, which evaluates cleanly through the full NixOS + home-manager module system) and confirmed all three `user_pref` lines are present with the expected values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)