### PR TITLE
email: European dd-mm-yyyy dates in Thunderbird

### DIFF
--- a/nix/email.nix
+++ b/nix/email.nix
@@ -290,7 +290,7 @@ in
           # intl.regional_prefs.use_os_locales = true, was rejected: it
           # switches every regional format at once and only says
           # "follow the OS", while this states the wanted format outright.
-          # ICU skeleton: dd = 2-digit day, MM = 2-digit month, yyyy = year.
+          # ICU pattern: dd = 2-digit day, MM = 2-digit month, yyyy = year.
           # Unlike the sort prefs above this applies on next start, no
           # profile wipe needed.
           "intl.date_time.pattern_override.date_short" = "dd-MM-yyyy";

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -283,7 +283,7 @@ in
           "mailnews.default_sort_order" = 2;
           "mailnews.default_view_flags" = 0;
 
-          # Decision: European dd-mm-yyyy dates via an explicit pattern
+          # Decision: European dd-MM-yyyy dates via an explicit pattern
           # override. Thunderbird formats dates with its bundled en-US app
           # locale and ignores the nl_NL OS locale of these machines, so the
           # message list showed 7/23/2026. The alternative,

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -282,6 +282,18 @@ in
           "mailnews.default_sort_type" = 18;
           "mailnews.default_sort_order" = 2;
           "mailnews.default_view_flags" = 0;
+
+          # Decision: European dd-mm-yyyy dates via an explicit pattern
+          # override. Thunderbird formats dates with its bundled en-US app
+          # locale and ignores the nl_NL OS locale of these machines, so the
+          # message list showed 7/23/2026. The alternative,
+          # intl.regional_prefs.use_os_locales = true, was rejected: it
+          # switches every regional format at once and only says
+          # "follow the OS", while this states the wanted format outright.
+          # ICU skeleton: dd = 2-digit day, MM = 2-digit month, yyyy = year.
+          # Unlike the sort prefs above this applies on next start, no
+          # profile wipe needed.
+          "intl.date_time.pattern_override.date_short" = "dd-MM-yyyy";
         };
       };
     };


### PR DESCRIPTION
## Summary
- Thunderbird formats dates with its bundled en-US app locale and ignores the nl_NL OS locale, so the message list showed 7/23/2026 on machines that are otherwise fully Dutch.
- Fix: `intl.date_time.pattern_override.date_short = "dd-MM-yyyy"` in the provisioned profile. The alternative `intl.regional_prefs.use_os_locales = true` is noted and rejected in a Decision comment (flips every regional format at once, and only indirectly).
- Applies on next Thunderbird start; unlike the sort prefs this is not cached per-folder, so no profile wipe needed.
- Verified: `nix-instantiate default.nix -A lenovo-tablet.config.system.build.toplevel` evaluates clean with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)