### PR TITLE
Provide ~/.config/git-hooks via home-manager, not install-nixos.sh

### DIFF
--- a/lenovo-amd-2022.nix
+++ b/lenovo-amd-2022.nix
@@ -26,6 +26,7 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
     ./nix/config.nix
     ./nix/environment.nix
     ./nix/email.nix
+    ./nix/git-hooks.nix
     ./nix/services.nix
   ];
 

--- a/lenovo-tablet.nix
+++ b/lenovo-tablet.nix
@@ -36,6 +36,7 @@ boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
     ./nix/config.nix
     ./nix/environment.nix
     ./nix/email.nix
+    ./nix/git-hooks.nix
     ./nix/services.nix
   ];
 

--- a/nix/email.nix
+++ b/nix/email.nix
@@ -11,9 +11,10 @@
 # so some address was always forgotten somewhere. Declaring them here
 # makes every machine converge on the same account list; only the
 # authentication of each account remains a manual, per machine step.
-# Adoption is deliberately narrow: only email lives in home-manager, all other
-# dotfiles keep using the symlink scheme from scripts/install-nixos.sh, which
-# allows live editing without a rebuild.
+# Adoption is deliberately narrow: only email and the global git hooks
+# (nix/git-hooks.nix) live in home-manager, all other dotfiles keep using the
+# symlink scheme from scripts/install-nixos.sh, which allows live editing
+# without a rebuild.
 { pkgs, config, ... }:
 let
   sources = import ../npins;

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -1,0 +1,27 @@
+# Global git hooks for the emacs dired/dirvish refresh.
+#
+# ~/.config/git-hooks (what core.hooksPath in dotfiles/jappie/.gitconfig
+# points at) is provided declaratively through home-manager; the
+# install-nixos.sh symlink scheme is not used for this, that script is
+# being phased out.
+#
+# Decision: mkOutOfStoreSymlink to the live checkout at /linux-config
+# instead of a plain xdg.configFile source. A plain source copies the
+# hooks into the nix store, so every hook edit would need a rebuild;
+# the out-of-store symlink keeps ~/.config/git-hooks pointing at the
+# working tree, the same live-editing behaviour the other dotfiles get
+# from their symlinks. Cost: the path /linux-config is hardcoded, which
+# install-nixos.sh already assumes everywhere else.
+{ ... }:
+let
+  sources = import ../npins;
+in
+{
+  imports = [ (sources.home-manager + "/nixos") ];
+
+  home-manager.users.jappie = { config, ... }: {
+    xdg.configFile."git-hooks".source =
+      config.lib.file.mkOutOfStoreSymlink
+        "/linux-config/dotfiles/jappie/.config/git-hooks";
+  };
+}

--- a/scripts/install-nixos.sh
+++ b/scripts/install-nixos.sh
@@ -51,8 +51,5 @@ ln -sf $CONFIG/startup.sh $HOME/.config/
 ln -sf $CONFIG/starship.toml $HOME/.config/
 ln -sf $CONFIG/mutt $HOME/.config/
 ln -sf $CONFIG/zsh-hacks.sh $HOME/.config/
-# -n: don't dereference an existing $HOME/.config/git-hooks symlink,
-# plain -sf would create a nested git-hooks/git-hooks on a re-run
-ln -sfn $CONFIG/git-hooks $HOME/.config/
 ln -sf $CONFIG/keepassxc/keepassxc.ini $HOME/.config/keepassxc/keepassxc.ini
 ln -sf $USER/.emacs.d/configuration.org $HOME/.config/emacsconfig.org

--- a/work-machine.nix
+++ b/work-machine.nix
@@ -8,6 +8,7 @@
     ./nix/config.nix
     ./nix/environment.nix
     ./nix/email.nix
+    ./nix/git-hooks.nix
     ./nix/services.nix
     /etc/nixos/cachix.nix
   ];


### PR DESCRIPTION
## Summary

Follow-up to #46, which was merged before this commit landed on the branch. Without it, the `core.hooksPath` in `.gitconfig` points at a `~/.config/git-hooks` that nothing creates: git then runs no hooks at all (repo-local ones included) and the dirvish refresh never fires.

- New `nix/git-hooks.nix` home-manager module, imported by all three machines, provides the `~/.config/git-hooks` symlink declaratively; `mkOutOfStoreSymlink` keeps it pointing at the live `/linux-config` checkout so hook edits apply without a rebuild.
- The `install-nixos.sh` symlink line from #46 is reverted; that script is being phased out.
- The narrow-adoption note in `email.nix` now names both home-manager residents.

## Test plan

- [x] Built the module's `hm_githooks` derivation from a minimal NixOS eval against the npins-pinned nixpkgs; it symlinks to `/linux-config/dotfiles/jappie/.config/git-hooks`
- [x] Replicated the deployed double-symlink chain in a sandbox HOME with a live emacs daemon: `git pull` refreshes an open dired listing through it, the repo-local hook still chains, and a pull exits 0 with no emacsclient on PATH
- [ ] After `nixos-rebuild switch` on a real machine: `readlink -f ~/.config/git-hooks` resolves into `/linux-config`, and a `git pull` refreshes an open dirvish buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)