### PR TITLE
Add jappie@webwinkelverhuis.nl to thunderbird accounts

### DIFF
--- a/nix/email.nix
+++ b/nix/email.nix
@@ -224,6 +224,18 @@ in
       };
       business = zohoEuAccount "hallo@jappiesoftware.com" // additiveBackup "mail-business";
 
+      # Google Workspace mailbox (the domain's MX points at smtp.google.com,
+      # not zoho). flavor gmail.com fills in the imap.gmail.com/smtp.gmail.com
+      # servers and defaults the auth to OAuth2, which Google requires; the
+      # login flow runs interactively once on first connect. Thunderbird-only
+      # like backup-personal: not mbsync-backed-up, that would need XOAUTH2.
+      webwinkelverhuis = {
+        address = "jappie@webwinkelverhuis.nl";
+        realName = "Jappie Klooster";
+        flavor = "gmail.com";
+        thunderbird.enable = true;
+      };
+
       # Not mbsync-backed-up: this is a Microsoft/hotmail mailbox, and MS has
       # been retiring basic-auth IMAP on personal accounts in favour of OAuth2,
       # so a plain passwordCommand is unreliable here. It stays a Thunderbird
@@ -271,6 +283,7 @@ in
         # primary (that stays personal)
         accountsOrder = [
           "business"
+          "webwinkelverhuis"
           "personal"
           "backup-personal"
         ];


### PR DESCRIPTION
## Summary
- Declares the jappie@webwinkelverhuis.nl mailbox in nix/email.nix so every machine provisions it, same motivation as the existing accounts (no more manually adding it per machine).
- The domain's MX points at smtp.google.com (Google Workspace), so it uses home-manager's gmail.com flavor: that fills in imap.gmail.com/smtp.gmail.com and defaults auth to OAuth2, which Google requires. The OAuth login runs interactively once on first connect.
- Thunderbird-only like backup-personal: no mbsync backup or retention, that would need XOAUTH2 wiring.
- Added to accountsOrder after business.

## Test plan
- [x] Standalone module eval via nixos eval-config: account list, gmail flavor, imap.gmail.com and the new accountsOrder all resolve
- [ ] nixos-rebuild switch on one machine, open Thunderbird, complete the Google OAuth prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)