### PR TITLE
Silence ble.sh "history: Broken pipe" in nix-shell prompts

### DIFF
--- a/dotfiles/jappie/.bashrc
+++ b/dotfiles/jappie/.bashrc
@@ -45,6 +45,22 @@ eval "$(fzf --bash)" # we do fzf first, so atuin overrides ctrl-r
 source -- "$(blesh-share)"/ble.sh --attach=none # attach does not work currently
 [[ ! ${BLE_VERSION-} ]] || ble-attach
 
+# Decision: override ble.sh's history "min" lookup with a pipe-free one.
+# ble.sh reimplements `history -a` (our PROMPT_COMMAND) and finds the
+# first history number with `builtin history | head -1`. head quits after
+# one line, so the history subshell writes into a closed pipe. In a shell
+# where SIGPIPE is ignored (every nix-shell, see NIX_BUILD_SHELL in
+# nix/environment.nix) that prints "history: schrijffout: Broken pipe"
+# twice per prompt and formats the whole history list each time.
+# `fc -l` with a large negative offset for both endpoints clamps to the
+# first entry in one line. `fc -l 1 1` was rejected: once entry 1 is
+# evicted by HISTSIZE it dumps the entire list. Upstream ble.sh master
+# still pipes through `sed 1q`, so this stays until that changes.
+function ble/builtin/history/.get-min {
+  ble/util/assign-words min 'builtin fc -l -9999999 -9999999'
+  min=${min/'*'}
+}
+
 
 eval "$(atuin init bash)"
 

--- a/nix/environment.nix
+++ b/nix/environment.nix
@@ -41,6 +41,20 @@ let
 
   fuckdirenv = pkgs.writeShellScriptBin "fuckdirenv" ''fd -t d -IH direnv --exec rm -r'';
 
+  # Decision: reset SIGPIPE for shells that nix-shell spawns, via a
+  # NIX_BUILD_SHELL wrapper rather than patching Lix. Lix ignores SIGPIPE
+  # in its own process and never restores it before exec'ing bash, so
+  # every nix-shell inherits the ignore, and bash cannot undo an
+  # inherited ignore (not even interactively). One visible symptom:
+  # ble.sh implements `history -a` with `builtin history | head -1`,
+  # which then prints "bash: history: schrijffout: Broken pipe" twice
+  # per prompt. Alternatives considered: `trap - PIPE` in .bashrc (a
+  # no-op for inherited ignores) and patching Lix (not our lever).
+  # Verified 2026-09-12 with Lix 2.95.2: SigIgn bit 0x1000 clears.
+  bash-default-sigpipe = pkgs.writeShellScript "bash-default-sigpipe" ''
+    exec ${pkgs.coreutils}/bin/env --default-signal=PIPE ${pkgs.bashInteractive}/bin/bash "$@"
+  '';
+
   reload-emacs = pkgs.writeShellScriptBin "reload-emacs" ''
     sudo nixos-rebuild switch && systemctl daemon-reload --user &&    systemctl restart emacs --user
   '';
@@ -521,6 +535,8 @@ in
     };
     variables = {
       LESS = "-F -X -R";
+      # see the bash-default-sigpipe decision above
+      NIX_BUILD_SHELL = "${bash-default-sigpipe}";
     };
     pathsToLink = [
       "/share/nix-direnv"


### PR DESCRIPTION
## Summary
- Every prompt inside a `nix-shell` printed `bash: history: schrijffout: Broken pipe` twice. Lix ignores SIGPIPE in its own process and never restores it before exec'ing bash, so nix-spawned shells inherit a hard-ignored SIGPIPE that bash cannot reset. Plain foot and Emacs shells are unaffected because both reset SIGPIPE for their children.
- ble.sh reimplements `history -a` (our `PROMPT_COMMAND`) and locates the first history number with `builtin history | head -1`. With SIGPIPE ignored the broken pipe becomes a printed write error instead of a silent kill, and the whole history list is formatted on every prompt (about 0.7 s per call at `HISTSIZE=1000000`, called twice).
- `NIX_BUILD_SHELL` now points at a wrapper that starts bash through `env --default-signal=PIPE`, restoring the normal SIGPIPE disposition inside every nix-shell.
- `.bashrc` overrides ble.sh's `.get-min` with `fc -l -9999999 -9999999`, which clamps both endpoints to the first entry in one line. `fc -l 1 1` was rejected: once entry 1 is evicted by `HISTSIZE` it dumps the entire list.
- Upstream ble.sh master still pipes through `sed 1q`, so the override stays until that changes.

## Test plan
- [x] Pseudo-terminal reproduction with the pinned blesh 0.4.0-devel3 and bash 5.3p3: unpatched shell with SIGPIPE ignored prints the message twice per prompt; with the override it prints nothing and writes a byte-identical history file, in both a young and an evicted-history regime.
- [x] `nix-shell -p hello` under Lix 2.95.2 with the built wrapper as `NIX_BUILD_SHELL`: `SigIgn` bit 0x1000 clears and `trap -p PIPE` prints nothing.
- [x] `nix-instantiate default.nix -A lenevo-amd-2022.config.system.build.toplevel` succeeds and resolves `NIX_BUILD_SHELL` to the same wrapper path that was tested.
- [ ] After `nixos-rebuild switch`, open a nix-shell for a Haskell project and confirm the prompt is quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHN3oDCynfbob92mYfdeY